### PR TITLE
Support Smithy IDL 2.0 syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-textmate-language:
+    runs-on: ubuntu-latest
+    name: Test Textmate syntax
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "smithy-vscode",
             "version": "0.3.0",
             "license": "Apache-2.0",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
             "version": "0.3.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "vscode-nls": "^3.2.4"
+                "vscode-nls": "^3.2.4",
+                "vscode-tmgrammar-test": "^0.0.11"
             },
             "devDependencies": {
                 "@types/node": "^10.12.12",
@@ -89,7 +90,6 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
             "dependencies": {
                 "color-convert": "^1.9.0"
             },
@@ -128,8 +128,7 @@
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
         "node_modules/big-integer": {
             "version": "1.6.49",
@@ -166,7 +165,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -234,7 +232,6 @@
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
             "dependencies": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -331,7 +328,6 @@
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
             "dependencies": {
                 "color-name": "1.1.3"
             }
@@ -339,8 +335,7 @@
         "node_modules/color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "node_modules/color-support": {
             "version": "1.1.3",
@@ -363,8 +358,7 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "node_modules/core-util-is": {
             "version": "1.0.3",
@@ -431,6 +425,14 @@
             "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
             "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
             "dev": true
+        },
+        "node_modules/diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "engines": {
+                "node": ">=0.3.1"
+            }
         },
         "node_modules/dom-serializer": {
             "version": "1.3.2",
@@ -521,7 +523,6 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true,
             "engines": {
                 "node": ">=0.8.0"
             }
@@ -586,8 +587,7 @@
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "node_modules/fstream": {
             "version": "1.0.12",
@@ -649,7 +649,6 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
             "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-            "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -687,7 +686,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -778,7 +776,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -787,8 +784,7 @@
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "node_modules/is": {
             "version": "3.3.0",
@@ -919,7 +915,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -982,7 +977,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -1097,7 +1091,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1339,7 +1332,6 @@
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
             "dependencies": {
                 "has-flag": "^3.0.0"
             },
@@ -1542,6 +1534,11 @@
                 "vscl": "lib/vscl.js"
             }
         },
+        "node_modules/vscode-oniguruma": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.5.1.tgz",
+            "integrity": "sha512-JrBZH8DCC262TEYcYdeyZusiETu0Vli0xFgdRwNJjDcObcRjbmJP+IFcA3ScBwIXwgFHYKbAgfxtM/Cl+3Spjw=="
+        },
         "node_modules/vscode-test": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
@@ -1556,6 +1553,33 @@
             "engines": {
                 "node": ">=8.9.3"
             }
+        },
+        "node_modules/vscode-textmate": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.4.1.tgz",
+            "integrity": "sha512-4CvPHmfuZQaXrcCpathdh6jo7myuR+MU8BvscgQADuponpbqfmu2rwTOtCXhGwwEgStvJF8V4s9FwMKRVLNmKQ=="
+        },
+        "node_modules/vscode-tmgrammar-test": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/vscode-tmgrammar-test/-/vscode-tmgrammar-test-0.0.11.tgz",
+            "integrity": "sha512-Bd60x/OeBLAQnIxiR2GhUic1CQZOFfWM8Pd43HjdEUBf/0vcvYAlFQikOXvv+zkItHLznjKaDX7VWKPVYUF9ug==",
+            "dependencies": {
+                "chalk": "^2.4.2",
+                "commander": "^2.20.3",
+                "diff": "^4.0.2",
+                "glob": "^7.1.6",
+                "vscode-oniguruma": "^1.5.1",
+                "vscode-textmate": "^5.4.0"
+            },
+            "bin": {
+                "vscode-tmgrammar-snap": "dist/src/snapshot.js",
+                "vscode-tmgrammar-test": "dist/src/unit.js"
+            }
+        },
+        "node_modules/vscode-tmgrammar-test/node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
         },
         "node_modules/which-module": {
             "version": "2.0.0",
@@ -1580,8 +1604,7 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "node_modules/xml2js": {
             "version": "0.4.23",
@@ -1718,7 +1741,6 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
             "requires": {
                 "color-convert": "^1.9.0"
             }
@@ -1751,8 +1773,7 @@
         "balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
         "big-integer": {
             "version": "1.6.49",
@@ -1786,7 +1807,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1839,7 +1859,6 @@
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -1918,7 +1937,6 @@
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
             "requires": {
                 "color-name": "1.1.3"
             }
@@ -1926,8 +1944,7 @@
         "color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "color-support": {
             "version": "1.1.3",
@@ -1944,8 +1961,7 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "core-util-is": {
             "version": "1.0.3",
@@ -1992,6 +2008,11 @@
             "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
             "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
             "dev": true
+        },
+        "diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
         },
         "dom-serializer": {
             "version": "1.3.2",
@@ -2060,8 +2081,7 @@
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "event-stream": {
             "version": "3.3.5",
@@ -2117,8 +2137,7 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fstream": {
             "version": "1.0.12",
@@ -2170,7 +2189,6 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
             "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -2198,8 +2216,7 @@
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "has-symbols": {
             "version": "1.0.2",
@@ -2262,7 +2279,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -2271,8 +2287,7 @@
         "inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "is": {
             "version": "3.3.0",
@@ -2381,7 +2396,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -2432,7 +2446,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -2522,8 +2535,7 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "pause-stream": {
             "version": "0.0.11",
@@ -2723,7 +2735,6 @@
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
             "requires": {
                 "has-flag": "^3.0.0"
             }
@@ -2895,6 +2906,11 @@
                 "yargs": "^13.2.4"
             }
         },
+        "vscode-oniguruma": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.5.1.tgz",
+            "integrity": "sha512-JrBZH8DCC262TEYcYdeyZusiETu0Vli0xFgdRwNJjDcObcRjbmJP+IFcA3ScBwIXwgFHYKbAgfxtM/Cl+3Spjw=="
+        },
         "vscode-test": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
@@ -2905,6 +2921,31 @@
                 "https-proxy-agent": "^5.0.0",
                 "rimraf": "^3.0.2",
                 "unzipper": "^0.10.11"
+            }
+        },
+        "vscode-textmate": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.4.1.tgz",
+            "integrity": "sha512-4CvPHmfuZQaXrcCpathdh6jo7myuR+MU8BvscgQADuponpbqfmu2rwTOtCXhGwwEgStvJF8V4s9FwMKRVLNmKQ=="
+        },
+        "vscode-tmgrammar-test": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/vscode-tmgrammar-test/-/vscode-tmgrammar-test-0.0.11.tgz",
+            "integrity": "sha512-Bd60x/OeBLAQnIxiR2GhUic1CQZOFfWM8Pd43HjdEUBf/0vcvYAlFQikOXvv+zkItHLznjKaDX7VWKPVYUF9ug==",
+            "requires": {
+                "chalk": "^2.4.2",
+                "commander": "^2.20.3",
+                "diff": "^4.0.2",
+                "glob": "^7.1.6",
+                "vscode-oniguruma": "^1.5.1",
+                "vscode-textmate": "^5.4.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.20.3",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+                }
             }
         },
         "which-module": {
@@ -2927,8 +2968,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "xml2js": {
             "version": "0.4.23",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
         ]
     },
     "scripts": {
-        "install-plugin": "vsce package -o smithy-vscode-test.vsix && code --install-extension smithy-vscode-test.vsix"
+        "install-plugin": "vsce package -o smithy-vscode-test.vsix && code --install-extension smithy-vscode-test.vsix",
+        "test": "npx vscode-tmgrammar-test -s 'source.smithy' -g syntaxes/smithy.tmLanguage -t 'tests/*'"
     },
     "devDependencies": {
         "@types/node": "^10.12.12",
@@ -50,6 +51,7 @@
         "vscode-test": "^1.4.0"
     },
     "dependencies": {
-        "vscode-nls": "^3.2.4"
+        "vscode-nls": "^3.2.4",
+        "vscode-tmgrammar-test": "^0.0.11"
     }
 }

--- a/syntaxes/smithy.tmLanguage
+++ b/syntaxes/smithy.tmLanguage
@@ -624,6 +624,23 @@
                     <string>punctuation.separator.dictionary.key-value.smithy</string>
                 </dict>
                 <dict>
+                    <key>match</key>
+                    <string>[^:](=)\s*(default)</string>
+                    <key>captures</key>
+                    <dict>
+                        <key>1</key>
+                        <dict>
+                            <key>name</key>
+                            <string>punctuation.separator.default.smithy</string>
+                        </dict>
+                        <key>2</key>
+                        <dict>
+                            <key>name</key>
+                            <string>keyword.other.smithy</string>
+                        </dict>
+                    </dict>
+                </dict>
+                <dict>
                     <key>name</key>
                     <string>meta.structure.dictionary.value.smithy</string>
                     <key>include</key>

--- a/syntaxes/smithy.tmLanguage
+++ b/syntaxes/smithy.tmLanguage
@@ -29,7 +29,7 @@
             <string>#comment</string>
         </dict>
 
-        <!-- Control statements: $version: "0.1.0"\n -->
+        <!-- Control statements: $version: "2.0"\n -->
         <dict>
             <key>name</key>
             <string>meta.keyword.statement.control.smithy</string>
@@ -513,6 +513,7 @@
                     <key>include</key>
                     <string>#value</string>
                 </dict>
+                <!-- NOTE: these aren't necessary as of idl 2.0 -->
                 <dict>
                     <key>match</key>
                     <string>,</string>
@@ -598,8 +599,6 @@
             </array>
         </dict>
 
-        <!-- Note: This allows for invalid key-value pairs like:
-             { : foo, : foo }... Maybe that's fine for highlighting? -->
         <key>object_inner</key>
         <dict>
             <key>patterns</key>
@@ -613,47 +612,40 @@
                     <string>#string_key</string>
                 </dict>
                 <dict>
-                    <key>begin</key>
+                    <key>match</key>
+                    <string>:=</string>
+                    <key>name</key>
+                    <string>punctuation.separator.dictionary.inline-struct.smithy</string>
+                </dict>
+                <dict>
+                    <key>match</key>
                     <string>:</string>
-                    <key>beginCaptures</key>
-                    <dict>
-                        <key>0</key>
-                        <dict>
-                            <key>name</key>
-                            <string>punctuation.separator.dictionary.key-value.smithy</string>
-                        </dict>
-                    </dict>
-                    <!-- This allows object_inner to be shared across traits and node values -->
-                    <key>end</key>
-                    <string>(,)|(?=\})|(?=\))</string>
-                    <key>endCaptures</key>
-                    <dict>
-                        <key>1</key>
-                        <dict>
-                            <key>name</key>
-                            <string>punctuation.separator.dictionary.pair.smithy</string>
-                        </dict>
-                    </dict>
+                    <key>name</key>
+                    <string>punctuation.separator.dictionary.key-value.smithy</string>
+                </dict>
+                <dict>
                     <key>name</key>
                     <string>meta.structure.dictionary.value.smithy</string>
-                    <key>patterns</key>
-                    <array>
-                        <dict>
-                            <key>include</key>
-                            <string>#value</string>
-                        </dict>
-                        <dict>
-                            <key>match</key>
-                            <string>[^\s,]</string>
-                            <key>name</key>
-                            <string>invalid.illegal.expected-dictionary-separator.smithy</string>
-                        </dict>
-                    </array>
+                    <key>include</key>
+                    <string>#value</string>
+                </dict>
+                <dict>
+                    <key>match</key>
+                    <string>!</string>
+                    <key>name</key>
+                    <string>keyword.operator.smithy</string>
+                </dict>
+                <dict>
+                    <key>match</key>
+                    <string>,</string>
+                    <key>name</key>
+                    <string>punctuation.separator.dictionary.pair.smithy</string>
                 </dict>
             </array>
         </dict>
 
-        <!-- A string or identifier used as an object key -->
+        <!-- A string or identifier used as an object key. These will only get
+             recognized if the full key is on the same line as colon separator. -->
         <key>string_key</key>
         <dict>
             <key>patterns</key>
@@ -674,20 +666,15 @@
             <key>name</key>
             <string>support.type.property-name.smithy</string>
             <key>match</key>
-            <string>[A-Z-a-z0-9_\.#$]+</string>
+            <string>[A-Z-a-z0-9_\.#$]+(?=\s*:)</string>
         </dict>
 
         <key>dquote_key</key>
         <dict>
             <key>name</key>
             <string>support.type.property-name.smithy</string>
-            <key>patterns</key>
-            <array>
-                <dict>
-                    <key>include</key>
-                    <string>#dquote</string>
-                </dict>
-            </array>
+            <key>match</key>
+            <string>".*"(?=\s*:)</string>
         </dict>
 
         <!-- A normal string value used in places like trait values,

--- a/syntaxes/smithy.tmLanguage
+++ b/syntaxes/smithy.tmLanguage
@@ -257,7 +257,7 @@
                 </dict>
                 <dict>
                     <key>include</key>
-                    <string>#object_inner</string>
+                    <string>#shape_inner</string>
                 </dict>
             </array>
         </dict>
@@ -307,7 +307,7 @@
                 </dict>
                 <dict>
                     <key>include</key>
-                    <string>#object_inner</string>
+                    <string>#shape_inner</string>
                 </dict>
             </array>
         </dict>
@@ -350,7 +350,7 @@
             <array>
                 <dict>
                     <key>include</key>
-                    <string>#object_inner</string>
+                    <string>#shape_inner</string>
                 </dict>
             </array>
         </dict>
@@ -694,6 +694,35 @@
                 </dict>
                 <dict>
                     <key>match</key>
+                    <string>:</string>
+                    <key>name</key>
+                    <string>punctuation.separator.dictionary.key-value.smithy</string>
+                </dict>
+                <dict>
+                    <key>name</key>
+                    <string>meta.structure.dictionary.value.smithy</string>
+                    <key>include</key>
+                    <string>#value</string>
+                </dict>
+                <dict>
+                    <key>match</key>
+                    <string>,</string>
+                    <key>name</key>
+                    <string>punctuation.separator.dictionary.pair.smithy</string>
+                </dict>
+            </array>
+        </dict>
+
+        <key>shape_inner</key>
+        <dict>
+            <key>patterns</key>
+            <array>
+                <dict>
+                    <key>include</key>
+                    <string>#trait</string>
+                </dict>
+                <dict>
+                    <key>match</key>
                     <string>:=</string>
                     <key>name</key>
                     <string>punctuation.separator.dictionary.inline-struct.smithy</string>
@@ -701,16 +730,6 @@
                 <dict>
                     <key>include</key>
                     <string>#with_statement</string>
-                </dict>
-                <dict>
-                    <key>include</key>
-                    <string>#trait</string>
-                </dict>
-                <dict>
-                    <key>match</key>
-                    <string>:</string>
-                    <key>name</key>
-                    <string>punctuation.separator.dictionary.key-value.smithy</string>
                 </dict>
                 <dict>
                     <key>match</key>
@@ -730,22 +749,14 @@
                     </dict>
                 </dict>
                 <dict>
-                    <key>name</key>
-                    <string>meta.structure.dictionary.value.smithy</string>
                     <key>include</key>
-                    <string>#value</string>
+                    <string>#object_inner</string>
                 </dict>
                 <dict>
                     <key>match</key>
                     <string>!</string>
                     <key>name</key>
                     <string>keyword.operator.smithy</string>
-                </dict>
-                <dict>
-                    <key>match</key>
-                    <string>,</string>
-                    <key>name</key>
-                    <string>punctuation.separator.dictionary.pair.smithy</string>
                 </dict>
             </array>
         </dict>

--- a/syntaxes/smithy.tmLanguage
+++ b/syntaxes/smithy.tmLanguage
@@ -484,7 +484,7 @@
                         <key>3</key>
                         <dict>
                             <key>name</key>
-                            <string>punctuation.definition.dictionary.end.smithy</string>
+                            <string>punctuation.definition.dictionary.begin.smithy</string>
                         </dict>
                     </dict>
                     <key>end</key>
@@ -749,14 +749,14 @@
                     </dict>
                 </dict>
                 <dict>
-                    <key>include</key>
-                    <string>#object_inner</string>
-                </dict>
-                <dict>
                     <key>match</key>
                     <string>!</string>
                     <key>name</key>
                     <string>keyword.operator.smithy</string>
+                </dict>
+                <dict>
+                    <key>include</key>
+                    <string>#object_inner</string>
                 </dict>
             </array>
         </dict>

--- a/syntaxes/smithy.tmLanguage
+++ b/syntaxes/smithy.tmLanguage
@@ -228,7 +228,7 @@
                 <key>0</key>
                 <dict>
                     <key>name</key>
-                    <string>punctuation.definition.object.end.smithy</string>
+                    <string>punctuation.definition.dictionary.end.smithy</string>
                 </dict>
             </dict>
             <key>beginCaptures</key>
@@ -246,7 +246,7 @@
                 <key>3</key>
                 <dict>
                     <key>name</key>
-                    <string>punctuation.definition.object.begin.smithy</string>
+                    <string>punctuation.definition.dictionary.begin.smithy</string>
                 </dict>
             </dict>
             <key>patterns</key>
@@ -274,7 +274,7 @@
                 <key>1</key>
                 <dict>
                     <key>name</key>
-                    <string>punctuation.definition.object.end.smithy</string>
+                    <string>punctuation.definition.dictionary.end.smithy</string>
                 </dict>
             </dict>
             <key>beginCaptures</key>
@@ -292,7 +292,7 @@
                 <key>3</key>
                 <dict>
                     <key>name</key>
-                    <string>punctuation.definition.object.begin.smithy</string>
+                    <string>punctuation.definition.dictionary.begin.smithy</string>
                 </dict>
             </dict>
             <key>patterns</key>
@@ -325,7 +325,7 @@
                 <key>0</key>
                 <dict>
                     <key>name</key>
-                    <string>punctuation.definition.object.end.smithy</string>
+                    <string>punctuation.definition.dictionary.end.smithy</string>
                 </dict>
             </dict>
             <key>beginCaptures</key>
@@ -343,7 +343,7 @@
                 <key>3</key>
                 <dict>
                     <key>name</key>
-                    <string>punctuation.definition.object.begin.smithy</string>
+                    <string>punctuation.definition.dictionary.begin.smithy</string>
                 </dict>
             </dict>
             <key>patterns</key>
@@ -484,7 +484,7 @@
                         <key>3</key>
                         <dict>
                             <key>name</key>
-                            <string>punctuation.definition.object.end.smithy</string>
+                            <string>punctuation.definition.dictionary.end.smithy</string>
                         </dict>
                     </dict>
                     <key>end</key>
@@ -494,7 +494,7 @@
                         <key>0</key>
                         <dict>
                             <key>name</key>
-                            <string>punctuation.definition.object.end.smithy</string>
+                            <string>punctuation.definition.dictionary.end.smithy</string>
                         </dict>
                     </dict>
                     <key>patterns</key>
@@ -656,7 +656,7 @@
                 <key>0</key>
                 <dict>
                     <key>name</key>
-                    <string>punctuation.definition.object.begin.smithy</string>
+                    <string>punctuation.definition.dictionary.begin.smithy</string>
                 </dict>
             </dict>
             <key>end</key>
@@ -666,7 +666,7 @@
                 <key>0</key>
                 <dict>
                     <key>name</key>
-                    <string>punctuation.definition.object.end.smithy</string>
+                    <string>punctuation.definition.dictionary.end.smithy</string>
                 </dict>
             </dict>
             <key>name</key>

--- a/syntaxes/smithy.tmLanguage
+++ b/syntaxes/smithy.tmLanguage
@@ -225,7 +225,7 @@
             <string>\}</string>
             <key>endCaptures</key>
             <dict>
-                <key>0</key>
+                <key>1</key>
                 <dict>
                     <key>name</key>
                     <string>punctuation.definition.object.end.smithy</string>
@@ -262,6 +262,56 @@
             </array>
         </dict>
 
+        <dict>
+            <key>name</key>
+            <string>meta.keyword.statement.shape.smithy</string>
+            <key>begin</key>
+            <string>^(structure)\s+([A-Z-a-z0-9_\.#$-]+)</string>
+            <key>end</key>
+            <string>\}</string>
+            <key>endCaptures</key>
+            <dict>
+                <key>1</key>
+                <dict>
+                    <key>name</key>
+                    <string>punctuation.definition.object.end.smithy</string>
+                </dict>
+            </dict>
+            <key>beginCaptures</key>
+            <dict>
+                <key>1</key>
+                <dict>
+                    <key>name</key>
+                    <string>keyword.statement.smithy</string>
+                </dict>
+                <key>2</key>
+                <dict>
+                    <key>name</key>
+                    <string>entity.name.type.smithy</string>
+                </dict>
+                <key>3</key>
+                <dict>
+                    <key>name</key>
+                    <string>punctuation.definition.object.begin.smithy</string>
+                </dict>
+            </dict>
+            <key>patterns</key>
+            <array>
+                <dict>
+                    <key>include</key>
+                    <string>#with_statement</string>
+                </dict>
+                <dict>
+                    <key>include</key>
+                    <string>#trait</string>
+                </dict>
+                <dict>
+                    <key>include</key>
+                    <string>#object_inner</string>
+                </dict>
+            </array>
+        </dict>
+
         <!-- Service shapes (they don't have members with traits) -->
         <dict>
             <key>name</key>
@@ -272,7 +322,7 @@
             <string>\}</string>
             <key>endCaptures</key>
             <dict>
-                <key>0</key>
+                <key>1</key>
                 <dict>
                     <key>name</key>
                     <string>punctuation.definition.object.end.smithy</string>
@@ -344,6 +394,37 @@
 
     <key>repository</key>
     <dict>
+        <key>with_statement</key>
+        <dict>
+            <key>begin</key>
+            <string>(with)</string>
+            <key>beginCaptures</key>
+            <dict>
+                <key>1</key>
+                <dict>
+                    <key>name</key>
+                    <string>keyword.statement.with.smithy</string>
+                </dict>
+            </dict>
+
+            <key>end</string>
+            <string>(?={)</string>
+
+            <key>patterns</key>
+            <array>
+                <dict>
+                    <key>include</key>
+                    <string>#identifier</string>
+                </dict>
+                <dict>
+                    <key>match</key>
+                    <string>,</string>
+                    <key>name</key>
+                    <string>punctuation.separator.array.smithy</string>
+                </dict>
+            </array>
+        </dict>
+
         <!-- Comments are either "///" or "//" -->
         <key>comment</key>
         <dict>
@@ -410,7 +491,7 @@
                     <string>\)</string>
                     <key>endCaptures</key>
                     <dict>
-                        <key>0</key>
+                        <key>1</key>
                         <dict>
                             <key>name</key>
                             <string>punctuation.definition.object.end.smithy</string>
@@ -489,7 +570,7 @@
             <string>\[</string>
             <key>beginCaptures</key>
             <dict>
-                <key>0</key>
+                <key>1</key>
                 <dict>
                     <key>name</key>
                     <string>punctuation.definition.array.begin.smithy</string>
@@ -499,7 +580,7 @@
             <string>\]</string>
             <key>endCaptures</key>
             <dict>
-                <key>0</key>
+                <key>1</key>
                 <dict>
                     <key>name</key>
                     <string>punctuation.definition.array.end.smithy</string>
@@ -572,7 +653,7 @@
             <string>\{</string>
             <key>beginCaptures</key>
             <dict>
-                <key>0</key>
+                <key>1</key>
                 <dict>
                     <key>name</key>
                     <string>punctuation.definition.dictionary.begin.smithy</string>
@@ -582,7 +663,7 @@
             <string>\}</string>
             <key>endCaptures</key>
             <dict>
-                <key>0</key>
+                <key>1</key>
                 <dict>
                     <key>name</key>
                     <string>punctuation.definition.dictionary.end.smithy</string>
@@ -616,6 +697,14 @@
                     <string>:=</string>
                     <key>name</key>
                     <string>punctuation.separator.dictionary.inline-struct.smithy</string>
+                </dict>
+                <dict>
+                    <key>include</key>
+                    <string>#with_statement</string>
+                </dict>
+                <dict>
+                    <key>include</key>
+                    <string>#trait</string>
                 </dict>
                 <dict>
                     <key>match</key>
@@ -723,7 +812,7 @@
             <string>"""</string>
             <key>beginCaptures</key>
             <dict>
-                <key>0</key>
+                <key>1</key>
                 <dict>
                     <key>name</key>
                     <string>punctuation.definition.string.begin.smithy</string>
@@ -733,7 +822,7 @@
             <string>"""</string>
             <key>endCaptures</key>
             <dict>
-                <key>0</key>
+                <key>1</key>
                 <dict>
                     <key>name</key>
                     <string>punctuation.definition.string.end.smithy</string>
@@ -758,7 +847,7 @@
             <string>"</string>
             <key>beginCaptures</key>
             <dict>
-                <key>0</key>
+                <key>1</key>
                 <dict>
                     <key>name</key>
                     <string>punctuation.definition.string.begin.smithy</string>
@@ -768,7 +857,7 @@
             <string>"</string>
             <key>endCaptures</key>
             <dict>
-                <key>0</key>
+                <key>1</key>
                 <dict>
                     <key>name</key>
                     <string>punctuation.definition.string.end.smithy</string>

--- a/syntaxes/smithy.tmLanguage
+++ b/syntaxes/smithy.tmLanguage
@@ -656,17 +656,17 @@
                 <key>0</key>
                 <dict>
                     <key>name</key>
-                    <string>punctuation.definition.dictionary.begin.smithy</string>
+                    <string>punctuation.definition.object.begin.smithy</string>
                 </dict>
             </dict>
             <key>end</key>
             <string>\}</string>
             <key>endCaptures</key>
             <dict>
-                <key>1</key>
+                <key>0</key>
                 <dict>
                     <key>name</key>
-                    <string>punctuation.definition.dictionary.end.smithy</string>
+                    <string>punctuation.definition.object.end.smithy</string>
                 </dict>
             </dict>
             <key>name</key>

--- a/syntaxes/smithy.tmLanguage
+++ b/syntaxes/smithy.tmLanguage
@@ -225,7 +225,7 @@
             <string>\}</string>
             <key>endCaptures</key>
             <dict>
-                <key>1</key>
+                <key>0</key>
                 <dict>
                     <key>name</key>
                     <string>punctuation.definition.object.end.smithy</string>
@@ -322,7 +322,7 @@
             <string>\}</string>
             <key>endCaptures</key>
             <dict>
-                <key>1</key>
+                <key>0</key>
                 <dict>
                     <key>name</key>
                     <string>punctuation.definition.object.end.smithy</string>
@@ -407,7 +407,7 @@
                 </dict>
             </dict>
 
-            <key>end</string>
+            <key>end</key>
             <string>(?={)</string>
 
             <key>patterns</key>
@@ -491,7 +491,7 @@
                     <string>\)</string>
                     <key>endCaptures</key>
                     <dict>
-                        <key>1</key>
+                        <key>0</key>
                         <dict>
                             <key>name</key>
                             <string>punctuation.definition.object.end.smithy</string>
@@ -570,7 +570,7 @@
             <string>\[</string>
             <key>beginCaptures</key>
             <dict>
-                <key>1</key>
+                <key>0</key>
                 <dict>
                     <key>name</key>
                     <string>punctuation.definition.array.begin.smithy</string>
@@ -580,7 +580,7 @@
             <string>\]</string>
             <key>endCaptures</key>
             <dict>
-                <key>1</key>
+                <key>0</key>
                 <dict>
                     <key>name</key>
                     <string>punctuation.definition.array.end.smithy</string>
@@ -653,7 +653,7 @@
             <string>\{</string>
             <key>beginCaptures</key>
             <dict>
-                <key>1</key>
+                <key>0</key>
                 <dict>
                     <key>name</key>
                     <string>punctuation.definition.dictionary.begin.smithy</string>
@@ -823,7 +823,7 @@
             <string>"""</string>
             <key>beginCaptures</key>
             <dict>
-                <key>1</key>
+                <key>0</key>
                 <dict>
                     <key>name</key>
                     <string>punctuation.definition.string.begin.smithy</string>
@@ -833,7 +833,7 @@
             <string>"""</string>
             <key>endCaptures</key>
             <dict>
-                <key>1</key>
+                <key>0</key>
                 <dict>
                     <key>name</key>
                     <string>punctuation.definition.string.end.smithy</string>
@@ -858,7 +858,7 @@
             <string>"</string>
             <key>beginCaptures</key>
             <dict>
-                <key>1</key>
+                <key>0</key>
                 <dict>
                     <key>name</key>
                     <string>punctuation.definition.string.begin.smithy</string>
@@ -868,7 +868,7 @@
             <string>"</string>
             <key>endCaptures</key>
             <dict>
-                <key>1</key>
+                <key>0</key>
                 <dict>
                     <key>name</key>
                     <string>punctuation.definition.string.end.smithy</string>

--- a/syntaxes/smithy.tmLanguage
+++ b/syntaxes/smithy.tmLanguage
@@ -177,12 +177,12 @@
             <string>#trait</string>
         </dict>
 
-        <!-- simple shapes: string Foo\n -->
+        <!-- shape declarations with mixins: string Foo with [Bar] -->
         <dict>
             <key>name</key>
             <string>meta.keyword.statement.shape.smithy</string>
             <key>begin</key>
-            <string>^(byte|short|integer|long|float|double|bigInteger|bigDecimal|boolean|blob|string|timestamp|document)\s+</string>
+            <string>^(byte|short|integer|long|float|double|bigInteger|bigDecimal|boolean|blob|string|timestamp|document|list|set|map|structure|union|service|operation|resource)\s+([A-Z-a-z_][A-Z-a-z0-9_]*)\s+(with)\s+(\[)</string>
             <key>beginCaptures</key>
             <dict>
                 <key>1</key>
@@ -190,9 +190,35 @@
                     <key>name</key>
                     <string>keyword.statement.smithy</string>
                 </dict>
+                <key>2</key>
+                <dict>
+                    <key>name</key>
+                    <string>entity.name.type.smithy</string>
+                </dict>
+                <key>3</key>
+                <dict>
+                    <key>name</key>
+                    <string>keyword.statement.with.smithy</string>
+                </dict>
+                <key>4</key>
+                <dict>
+                    <key>name</key>
+                    <string>punctuation.definition.array.begin.smithy</string>
+                </dict>
             </dict>
+
             <key>end</key>
-            <string>\n</string>
+            <string>\]</string>
+            <key>endCaptures</key>
+            <dict>
+                <key>0</key>
+                <dict>
+                    <key>name</key>
+                    <string>punctuation.definition.array.end.smithy</string>
+                </dict>
+            </dict>
+
+
             <key>patterns</key>
             <array>
                 <dict>
@@ -207,20 +233,47 @@
                 </dict>
                 <dict>
                     <key>match</key>
-                    <string>[^\n]</string>
+                    <string>,</string>
                     <key>name</key>
-                    <string>invalid.illegal.shape.smithy</string>
+                    <string>punctuation.separator.array.smithy</string>
                 </dict>
             </array>
         </dict>
 
-        <!-- Aggregate shapes (these have members with traits) -->
-        <!-- list Foo { member: Bar } -->
+        <!-- shape declarations without mixins: string Foo\n -->
         <dict>
             <key>name</key>
             <string>meta.keyword.statement.shape.smithy</string>
+            <key>match</key>
+            <string>^(byte|short|integer|long|float|double|bigInteger|bigDecimal|boolean|blob|string|timestamp|document|list|set|map|structure|union|service|operation|resource)\s+([A-Z-a-z_][A-Z-a-z0-9_]*)</string>
+            <key>captures</key>
+            <dict>
+                <key>1</key>
+                <dict>
+                    <key>name</key>
+                    <string>keyword.statement.smithy</string>
+                </dict>
+                <key>2</key>
+                <dict>
+                    <key>name</key>
+                    <string>entity.name.type.smithy</string>
+                </dict>
+            </dict>
+        </dict>
+
+        <!-- shape property bags -->
+        <dict>
             <key>begin</key>
-            <string>^(list|set|map|structure|union)\s+([A-Z-a-z0-9_\.#$-]+)\s*(\{)</string>
+            <string>\{</string>
+            <key>beginCaptures</key>
+            <dict>
+                <key>0</key>
+                <dict>
+                    <key>name</key>
+                    <string>punctuation.definition.dictionary.begin.smithy</string>
+                </dict>
+            </dict>
+
             <key>end</key>
             <string>\}</string>
             <key>endCaptures</key>
@@ -231,121 +284,7 @@
                     <string>punctuation.definition.dictionary.end.smithy</string>
                 </dict>
             </dict>
-            <key>beginCaptures</key>
-            <dict>
-                <key>1</key>
-                <dict>
-                    <key>name</key>
-                    <string>keyword.statement.smithy</string>
-                </dict>
-                <key>2</key>
-                <dict>
-                    <key>name</key>
-                    <string>entity.name.type.smithy</string>
-                </dict>
-                <key>3</key>
-                <dict>
-                    <key>name</key>
-                    <string>punctuation.definition.dictionary.begin.smithy</string>
-                </dict>
-            </dict>
-            <key>patterns</key>
-            <array>
-                <dict>
-                    <key>include</key>
-                    <string>#trait</string>
-                </dict>
-                <dict>
-                    <key>include</key>
-                    <string>#shape_inner</string>
-                </dict>
-            </array>
-        </dict>
 
-        <dict>
-            <key>name</key>
-            <string>meta.keyword.statement.shape.smithy</string>
-            <key>begin</key>
-            <string>^(structure)\s+([A-Z-a-z0-9_\.#$-]+)</string>
-            <key>end</key>
-            <string>\}</string>
-            <key>endCaptures</key>
-            <dict>
-                <key>1</key>
-                <dict>
-                    <key>name</key>
-                    <string>punctuation.definition.dictionary.end.smithy</string>
-                </dict>
-            </dict>
-            <key>beginCaptures</key>
-            <dict>
-                <key>1</key>
-                <dict>
-                    <key>name</key>
-                    <string>keyword.statement.smithy</string>
-                </dict>
-                <key>2</key>
-                <dict>
-                    <key>name</key>
-                    <string>entity.name.type.smithy</string>
-                </dict>
-                <key>3</key>
-                <dict>
-                    <key>name</key>
-                    <string>punctuation.definition.dictionary.begin.smithy</string>
-                </dict>
-            </dict>
-            <key>patterns</key>
-            <array>
-                <dict>
-                    <key>include</key>
-                    <string>#with_statement</string>
-                </dict>
-                <dict>
-                    <key>include</key>
-                    <string>#trait</string>
-                </dict>
-                <dict>
-                    <key>include</key>
-                    <string>#shape_inner</string>
-                </dict>
-            </array>
-        </dict>
-
-        <!-- Service shapes (they don't have members with traits) -->
-        <dict>
-            <key>name</key>
-            <string>meta.keyword.statement.shape.smithy</string>
-            <key>begin</key>
-            <string>^(apply|service|operation|resource)\s+([A-Z-a-z0-9_]+)\s*(\{)</string>
-            <key>end</key>
-            <string>\}</string>
-            <key>endCaptures</key>
-            <dict>
-                <key>0</key>
-                <dict>
-                    <key>name</key>
-                    <string>punctuation.definition.dictionary.end.smithy</string>
-                </dict>
-            </dict>
-            <key>beginCaptures</key>
-            <dict>
-                <key>1</key>
-                <dict>
-                    <key>name</key>
-                    <string>keyword.statement.smithy</string>
-                </dict>
-                <key>2</key>
-                <dict>
-                    <key>name</key>
-                    <string>entity.name.type.smithy</string>
-                </dict>
-                <key>3</key>
-                <dict>
-                    <key>name</key>
-                    <string>punctuation.definition.dictionary.begin.smithy</string>
-                </dict>
-            </dict>
             <key>patterns</key>
             <array>
                 <dict>
@@ -397,7 +336,7 @@
         <key>with_statement</key>
         <dict>
             <key>begin</key>
-            <string>(with)</string>
+            <string>(with)\s+(\[)</string>
             <key>beginCaptures</key>
             <dict>
                 <key>1</key>
@@ -405,22 +344,39 @@
                     <key>name</key>
                     <string>keyword.statement.with.smithy</string>
                 </dict>
+                <key>2</key>
+                <dict>
+                    <key>name</key>
+                    <string>punctuation.definition.array.begin.smithy</string>
+                </dict>
             </dict>
 
             <key>end</key>
-            <string>(?={)</string>
+            <string>\]</string>
+            <key>endCaptures</key>
+            <dict>
+                <key>0</key>
+                <dict>
+                    <key>name</key>
+                    <string>punctuation.definition.array.end.smithy</string>
+                </dict>
+            </dict>
 
             <key>patterns</key>
             <array>
-                <dict>
-                    <key>include</key>
-                    <string>#identifier</string>
-                </dict>
                 <dict>
                     <key>match</key>
                     <string>,</string>
                     <key>name</key>
                     <string>punctuation.separator.array.smithy</string>
+                </dict>
+                <dict>
+                    <key>include</key>
+                    <string>#identifier</string>
+                </dict>
+                <dict>
+                    <key>include</key>
+                    <string>#comment</string>
                 </dict>
             </array>
         </dict>
@@ -730,29 +686,6 @@
                 <dict>
                     <key>include</key>
                     <string>#with_statement</string>
-                </dict>
-                <dict>
-                    <key>match</key>
-                    <string>[^:](=)\s*(default)</string>
-                    <key>captures</key>
-                    <dict>
-                        <key>1</key>
-                        <dict>
-                            <key>name</key>
-                            <string>punctuation.separator.default.smithy</string>
-                        </dict>
-                        <key>2</key>
-                        <dict>
-                            <key>name</key>
-                            <string>keyword.other.smithy</string>
-                        </dict>
-                    </dict>
-                </dict>
-                <dict>
-                    <key>match</key>
-                    <string>!</string>
-                    <key>name</key>
-                    <string>keyword.operator.smithy</string>
                 </dict>
                 <dict>
                     <key>include</key>

--- a/tests/aggregate-shapes.smithy
+++ b/tests/aggregate-shapes.smithy
@@ -1,0 +1,87 @@
+// SYNTAX TEST "source.smithy" "This tests aggregate shapes"
+$version: "2.0"
+
+namespace com.example
+
+list List {
+// <----    keyword.statement.smithy
+//   ^^^^   entity.name.type.smithy
+//        ^ punctuation.definition.dictionary.begin.smithy
+
+    member: String
+//  ^^^^^^         support.type.property-name.smithy
+//        ^        punctuation.separator.dictionary.key-value.smithy
+//          ^^^^^^ entity.name.type.smithy
+
+}
+// <- punctuation.definition.dictionary.end.smithy
+
+set Set {
+// <---   keyword.statement.smithy
+//  ^^^   entity.name.type.smithy
+//      ^ punctuation.definition.dictionary.begin.smithy
+
+    member: String
+//  ^^^^^^         support.type.property-name.smithy
+//        ^        punctuation.separator.dictionary.key-value.smithy
+//          ^^^^^^ entity.name.type.smithy
+
+}
+// <- punctuation.definition.dictionary.end.smithy
+
+map Map {
+// <---   keyword.statement.smithy
+//  ^^^   entity.name.type.smithy
+//      ^ punctuation.definition.dictionary.begin.smithy
+
+    key: String
+//  ^^^         support.type.property-name.smithy
+//     ^        punctuation.separator.dictionary.key-value.smithy
+//       ^^^^^^ entity.name.type.smithy
+
+    value: String
+//  ^^^^^         support.type.property-name.smithy
+//       ^        punctuation.separator.dictionary.key-value.smithy
+//         ^^^^^^ entity.name.type.smithy
+
+}
+// <- punctuation.definition.dictionary.end.smithy
+
+structure Structure {
+// <---------         keyword.statement.smithy
+//        ^^^^^^^^^   entity.name.type.smithy
+//                  ^ punctuation.definition.dictionary.begin.smithy
+
+    basic: String
+//  ^^^^^         support.type.property-name.smithy
+//       ^        punctuation.separator.dictionary.key-value.smithy
+//         ^^^^^^ entity.name.type.smithy
+
+    required: String!
+//  ^^^^^^^^          support.type.property-name.smithy
+//          ^         punctuation.separator.dictionary.key-value.smithy
+//            ^^^^^^  entity.name.type.smithy
+//                  ^ keyword.operator.smithy
+
+    default: String = default
+//  ^^^^^^^                   support.type.property-name.smithy
+//         ^                  punctuation.separator.dictionary.key-value.smithy
+//           ^^^^^^           entity.name.type.smithy
+//                  ^         punctuation.separator.default.smithy
+//                    ^^^^^^^ keyword.other.smithy
+
+}
+// <- punctuation.definition.dictionary.end.smithy
+
+union Union {
+// <-----     keyword.statement.smithy
+//    ^^^^^   entity.name.type.smithy
+//          ^ punctuation.definition.dictionary.begin.smithy
+
+    foo: String
+//  ^^^         support.type.property-name.smithy
+//     ^        punctuation.separator.dictionary.key-value.smithy
+//       ^^^^^^ entity.name.type.smithy
+
+}
+// <- punctuation.definition.dictionary.end.smithy

--- a/tests/aggregate-shapes.smithy
+++ b/tests/aggregate-shapes.smithy
@@ -57,19 +57,6 @@ structure Structure {
 //       ^        punctuation.separator.dictionary.key-value.smithy
 //         ^^^^^^ entity.name.type.smithy
 
-    required: String!
-//  ^^^^^^^^          support.type.property-name.smithy
-//          ^         punctuation.separator.dictionary.key-value.smithy
-//            ^^^^^^  entity.name.type.smithy
-//                  ^ keyword.operator.smithy
-
-    default: String = default
-//  ^^^^^^^                   support.type.property-name.smithy
-//         ^                  punctuation.separator.dictionary.key-value.smithy
-//           ^^^^^^           entity.name.type.smithy
-//                  ^         punctuation.separator.default.smithy
-//                    ^^^^^^^ keyword.other.smithy
-
 }
 // <- punctuation.definition.dictionary.end.smithy
 

--- a/tests/control.smithy
+++ b/tests/control.smithy
@@ -1,0 +1,7 @@
+// SYNTAX TEST "source.smithy" "This tests control statments"
+
+$version: "2.0"
+// <-           keyword.statement.control.smithy
+// <~-------    support.type.property-name.smithy
+//      ^       punctuation.separator.dictionary.pair.smithy
+//        ^^^^^ string.quoted.double.smithy

--- a/tests/metadata.smithy
+++ b/tests/metadata.smithy
@@ -1,0 +1,11 @@
+// SYNTAX TEST "source.smithy" "This tests metadata statments"
+$version: "2.0"
+
+metadata foo = "bar"
+// <--------         keyword.statement.smithy
+//       ^^^         variable.other.smithy
+//           ^       keyword.operator.smithy
+//             ^^^^^ string.quoted.double.smithy
+
+metadata "foo" = "bar"
+//       ^^^^^         variable.other.smithy

--- a/tests/mixins.smithy
+++ b/tests/mixins.smithy
@@ -1,0 +1,273 @@
+// SYNTAX TEST "source.smithy" "This tests using mixins on all shape types"
+$version: "2.0"
+
+namespace smithy.example
+
+@mixin
+blob MixinBlob
+
+blob MixedBlob with [MixinBlob]
+// <----                        keyword.statement.smithy
+//   ^^^^^^^^^                  entity.name.type.smithy
+//             ^^^^             keyword.statement.with.smithy
+//                  ^           punctuation.definition.array.begin.smithy
+//                   ^^^^^^^^^  entity.name.type.smithy
+//                            ^ punctuation.definition.array.end.smithy
+
+@mixin
+boolean MixinBoolean
+
+boolean MixedBoolean with [MixinBoolean]
+// <-------                              keyword.statement.smithy
+//      ^^^^^^^^^^^^                     entity.name.type.smithy
+//                   ^^^^                keyword.statement.with.smithy
+//                        ^              punctuation.definition.array.begin.smithy
+//                         ^^^^^^^^^^^^  entity.name.type.smithy
+//                                     ^ punctuation.definition.array.end.smithy
+
+@mixin
+string MixinString
+
+string MixedString with [MixinString]
+// <------                            keyword.statement.smithy
+//     ^^^^^^^^^^^                    entity.name.type.smithy
+//                 ^^^^               keyword.statement.with.smithy
+//                      ^             punctuation.definition.array.begin.smithy
+//                       ^^^^^^^^^^^  entity.name.type.smithy
+//                                  ^ punctuation.definition.array.end.smithy
+
+@mixin
+byte MixinByte
+
+byte MixedByte with [MixinByte]
+// <----                        keyword.statement.smithy
+//   ^^^^^^^^^                  entity.name.type.smithy
+//             ^^^^             keyword.statement.with.smithy
+//                  ^           punctuation.definition.array.begin.smithy
+//                   ^^^^^^^^^  entity.name.type.smithy
+//                            ^ punctuation.definition.array.end.smithy
+
+@mixin
+short MixinShort
+
+short MixedShort with [MixinShort]
+// <-----                          keyword.statement.smithy
+//    ^^^^^^^^^^                   entity.name.type.smithy
+//               ^^^^              keyword.statement.with.smithy
+//                    ^            punctuation.definition.array.begin.smithy
+//                     ^^^^^^^^^^  entity.name.type.smithy
+//                               ^ punctuation.definition.array.end.smithy
+
+@mixin
+integer MixinInteger
+
+integer MixedInteger with [MixinInteger]
+// <-------                              keyword.statement.smithy
+//      ^^^^^^^^^                        entity.name.type.smithy
+//                   ^^^^                keyword.statement.with.smithy
+//                        ^              punctuation.definition.array.begin.smithy
+//                         ^^^^^^^^^^^^  entity.name.type.smithy
+//                                     ^ punctuation.definition.array.end.smithy
+
+@mixin
+long MixinLong
+
+long MixedLong with [MixinLong]
+// <----                        keyword.statement.smithy
+//   ^^^^^^^^^                  entity.name.type.smithy
+//             ^^^^             keyword.statement.with.smithy
+//                  ^           punctuation.definition.array.begin.smithy
+//                   ^^^^^^^^^  entity.name.type.smithy
+//                            ^ punctuation.definition.array.end.smithy
+
+@mixin
+float MixinFloat
+
+float MixedFloat with [MixinFloat]
+// <-----                          keyword.statement.smithy
+//    ^^^^^^^^^^                   entity.name.type.smithy
+//               ^^^^              keyword.statement.with.smithy
+//                    ^            punctuation.definition.array.begin.smithy
+//                     ^^^^^^^^^^  entity.name.type.smithy
+//                               ^ punctuation.definition.array.end.smithy
+
+@mixin
+double MixinDouble
+
+double MixedDouble with [MixinDouble]
+// <------                            keyword.statement.smithy
+//     ^^^^^^^^^^^                    entity.name.type.smithy
+//                 ^^^^               keyword.statement.with.smithy
+//                      ^             punctuation.definition.array.begin.smithy
+//                       ^^^^^^^^^^^  entity.name.type.smithy
+//                                  ^ punctuation.definition.array.end.smithy
+
+@mixin
+bigInteger MixinBigInt
+
+bigInteger MixedBigInt with [MixinBigInt]
+// <----------                            keyword.statement.smithy
+//         ^^^^^^^^^^^                    entity.name.type.smithy
+//                     ^^^^               keyword.statement.with.smithy
+//                          ^             punctuation.definition.array.begin.smithy
+//                           ^^^^^^^^^^^  entity.name.type.smithy
+//                                      ^ punctuation.definition.array.end.smithy
+
+@mixin
+bigDecimal MixinBigDecimal
+
+bigDecimal MixedBigDecimal with [MixinBigDecimal]
+// <----------                                    keyword.statement.smithy
+//         ^^^^^^^^^^^^^^^                        entity.name.type.smithy
+//                         ^^^^                   keyword.statement.with.smithy
+//                              ^                 punctuation.definition.array.begin.smithy
+//                               ^^^^^^^^^^^^^^^  entity.name.type.smithy
+//                                              ^ punctuation.definition.array.end.smithy
+
+@mixin
+timestamp MixinTimestamp
+
+timestamp MixedTimestamp with [MixinTimestamp]
+// <---------                                  keyword.statement.smithy
+//        ^^^^^^^^^^^^^^                       entity.name.type.smithy
+//                       ^^^^                  keyword.statement.with.smithy
+//                            ^                punctuation.definition.array.begin.smithy
+//                             ^^^^^^^^^^^^^^  entity.name.type.smithy
+//                                           ^ punctuation.definition.array.end.smithy
+
+@mixin
+document MixinDocument
+
+document MixedDocument with [MixinDocument]
+// <--------                                keyword.statement.smithy
+//       ^^^^^^^^^^^^^                      entity.name.type.smithy
+//                     ^^^^                 keyword.statement.with.smithy
+//                          ^               punctuation.definition.array.begin.smithy
+//                           ^^^^^^^^^^^^^  entity.name.type.smithy
+//                                        ^ punctuation.definition.array.end.smithy
+
+
+list MixedList with [MixinList] {}
+// <----                           keyword.statement.smithy
+//   ^^^^^^^^^                     entity.name.type.smithy
+//             ^^^^                keyword.statement.with.smithy
+//                  ^              punctuation.definition.array.begin.smithy
+//                   ^^^^^^^^^     entity.name.type.smithy
+//                            ^    punctuation.definition.array.end.smithy
+//                              ^  punctuation.definition.dictionary.begin.smithy
+//                               ^ punctuation.definition.dictionary.end.smithy
+
+@mixin
+set MixinSet {
+    member: String
+}
+
+set MixedSet with [MixinSet] {}
+// <---                         keyword.statement.smithy
+//  ^^^^^^^^                    entity.name.type.smithy
+//           ^^^^               keyword.statement.with.smithy
+//                ^             punctuation.definition.array.begin.smithy
+//                 ^^^^^^^^     entity.name.type.smithy
+//                         ^    punctuation.definition.array.end.smithy
+//                           ^  punctuation.definition.dictionary.begin.smithy
+//                            ^ punctuation.definition.dictionary.end.smithy
+
+@mixin
+map MixinMap {
+    key: String
+    value: String
+}
+
+map MixedMap with [MixinMap] {}
+// <---                         keyword.statement.smithy
+//  ^^^^^^^^                    entity.name.type.smithy
+//           ^^^^               keyword.statement.with.smithy
+//                ^             punctuation.definition.array.begin.smithy
+//                 ^^^^^^^^     entity.name.type.smithy
+//                         ^    punctuation.definition.array.end.smithy
+//                           ^  punctuation.definition.dictionary.begin.smithy
+//                            ^ punctuation.definition.dictionary.end.smithy
+
+@mixin
+structure MixinStructure {}
+
+structure MixedStructure with [MixinStructure] {}
+// <---------                                     keyword.statement.smithy
+//        ^^^^^^^^^^^^^^                          entity.name.type.smithy
+//                       ^^^^                     keyword.statement.with.smithy
+//                            ^                   punctuation.definition.array.begin.smithy
+//                             ^^^^^^^^^^^^^^     entity.name.type.smithy
+//                                           ^    punctuation.definition.array.end.smithy
+//                                             ^  punctuation.definition.dictionary.begin.smithy
+//                                              ^ punctuation.definition.dictionary.end.smithy
+
+@mixin
+service MixinService {}
+
+service MixedService with [MixinService] {}
+// <-------                                 keyword.statement.smithy
+//      ^^^^^^^^^^^^                        entity.name.type.smithy
+//                   ^^^^                   keyword.statement.with.smithy
+//                        ^                 punctuation.definition.array.begin.smithy
+//                         ^^^^^^^^^^^^     entity.name.type.smithy
+//                                     ^    punctuation.definition.array.end.smithy
+//                                       ^  punctuation.definition.dictionary.begin.smithy
+//                                        ^ punctuation.definition.dictionary.end.smithy
+
+@mixin
+resource MixinResource {}
+
+resource MixedResource with [MixinResource] {}
+// <--------                                   keyword.statement.smithy
+//       ^^^^^^^^^^^^^                         entity.name.type.smithy
+//                     ^^^^                    keyword.statement.with.smithy
+//                          ^                  punctuation.definition.array.begin.smithy
+//                           ^^^^^^^^^^^^^     entity.name.type.smithy
+//                                        ^    punctuation.definition.array.end.smithy
+//                                          ^  punctuation.definition.dictionary.begin.smithy
+//                                           ^ punctuation.definition.dictionary.end.smithy
+
+@mixin
+operation MixinOperation {}
+
+operation MixedOperation with [MixinOperation] {}
+// <---------                                     keyword.statement.smithy
+//        ^^^^^^^^^^^^^^                          entity.name.type.smithy
+//                       ^^^^                     keyword.statement.with.smithy
+//                            ^                   punctuation.definition.array.begin.smithy
+//                             ^^^^^^^^^^^^^^     entity.name.type.smithy
+//                                           ^    punctuation.definition.array.end.smithy
+//                                             ^  punctuation.definition.dictionary.begin.smithy
+//                                              ^ punctuation.definition.dictionary.end.smithy
+
+@mixin
+operation MixinOperation2 {}
+
+operation MultiMixedOperation with [
+// <---------                        keyword.statement.smithy
+//        ^^^^^^^^^^^^^^^^^^^        entity.name.type.smithy
+//                            ^^^^   keyword.statement.with.smithy
+//                                 ^ punctuation.definition.array.begin.smithy
+
+    MixinOperation
+//  ^^^^^^^^^^^^^^ entity.name.type.smithy
+
+    MixinOperation2
+//  ^^^^^^^^^^^^^^^ entity.name.type.smithy
+
+] {}
+// <-   punctuation.definition.array.end.smithy
+// <~~- punctuation.definition.dictionary.begin.smithy
+// ^    punctuation.definition.dictionary.end.smithy
+
+operation MultiMixedOperation2 with [MixinOperation, MixinOperation2] {}
+// <---------                                                            keyword.statement.smithy
+//        ^^^^^^^^^^^^^^^^^^^^                                           entity.name.type.smithy
+//                             ^^^^                                      keyword.statement.with.smithy
+//                                  ^                                    punctuation.definition.array.begin.smithy
+//                                   ^^^^^^^^^^^^^^                      entity.name.type.smithy
+//                                                 ^                     punctuation.separator.array.smithy
+//                                                   ^^^^^^^^^^^^^^^     entity.name.type.smithy
+//                                                                  ^    punctuation.definition.array.end.smithy
+//                                                                    ^  punctuation.definition.dictionary.begin.smithy
+//                                                                     ^ punctuation.definition.dictionary.end.smithy

--- a/tests/namespace.smithy
+++ b/tests/namespace.smithy
@@ -1,0 +1,6 @@
+// SYNTAX TEST "source.smithy" "This tests the namespace section"
+$version: "2.0"
+
+namespace com.example
+// <---------         keyword.statement.smithy
+//        ^^^^^^^^^^^ entity.name.type.smithy

--- a/tests/service-shapes.smithy
+++ b/tests/service-shapes.smithy
@@ -104,13 +104,15 @@ operation OtherOperation {
 //        ^^^^^^^^^^^^^^   entity.name.type.smithy
 //                       ^ punctuation.definition.dictionary.begin.smithy
 
-    input := with Bar {}
-//  ^^^^^                support.type.property-name.smithy
-//        ^^             punctuation.separator.dictionary.inline-struct.smithy
-//           ^^^^        keyword.statement.with.smithy
-//                ^^^    entity.name.type.smithy
-//                    ^  punctuation.definition.dictionary.begin.smithy
-//                     ^ punctuation.definition.dictionary.end.smithy
+    input := with [Bar] {}
+//  ^^^^^                  support.type.property-name.smithy
+//        ^^               punctuation.separator.dictionary.inline-struct.smithy
+//           ^^^^          keyword.statement.with.smithy
+//                ^        punctuation.definition.array.begin.smithy
+//                 ^^^     entity.name.type.smithy
+//                    ^    punctuation.definition.array.end.smithy
+//                      ^  punctuation.definition.dictionary.begin.smithy
+//                       ^ punctuation.definition.dictionary.end.smithy
 
     output := @sensitive {}
 //  ^^^^^^                  support.type.property-name.smithy

--- a/tests/service-shapes.smithy
+++ b/tests/service-shapes.smithy
@@ -77,19 +77,6 @@ operation Operation {
 //         ^     punctuation.separator.dictionary.key-value.smithy
 //           ^^^ entity.name.type.smithy
 
-        bar: Bar!
-//      ^^^       support.type.property-name.smithy
-//         ^      punctuation.separator.dictionary.key-value.smithy
-//           ^^^  entity.name.type.smithy
-// TODO         ^ keyword.operator.smithy
-
-        baz: Bar = default
-//      ^^^                support.type.property-name.smithy
-//         ^               punctuation.separator.dictionary.key-value.smithy
-//           ^^^           entity.name.type.smithy
-// TODO          ^         punctuation.separator.default.smithy
-// TODO            ^^^^^^^ keyword.other.smithy
-
     }
 //  ^ punctuation.definition.dictionary.end.smithy
 

--- a/tests/service-shapes.smithy
+++ b/tests/service-shapes.smithy
@@ -1,0 +1,221 @@
+// SYNTAX TEST "source.smithy" "This tests resource shapes"
+$version: "2.0"
+
+namespace com.example
+
+service Service {
+// <-------       keyword.statement.smithy
+//      ^^^^^^^   entity.name.type.smithy
+//              ^ punctuation.definition.dictionary.begin.smithy
+
+    version: "2020-02-02"
+//  ^^^^^^^               support.type.property-name.smithy
+//         ^              punctuation.separator.dictionary.key-value.smithy
+//           ^^^^^^^^^^^^ string.quoted.double.smithy
+
+    operations: [
+//  ^^^^^^^^^^    support.type.property-name.smithy
+//            ^   punctuation.separator.dictionary.key-value.smithy
+//              ^ punctuation.definition.array.begin.smithy
+
+        Operation
+//      ^^^^^^^^^ entity.name.type.smithy
+
+    ]
+//  ^ punctuation.definition.array.end.smithy
+
+    resources: [
+//  ^^^^^^^^^    support.type.property-name.smithy
+//           ^   punctuation.separator.dictionary.key-value.smithy
+//             ^ punctuation.definition.array.begin.smithy
+
+        Resource
+//      ^^^^^^^^ entity.name.type.smithy
+
+    ]
+//  ^ punctuation.definition.array.end.smithy
+
+    errors: [
+//  ^^^^^^    support.type.property-name.smithy
+//        ^   punctuation.separator.dictionary.key-value.smithy
+//          ^ punctuation.definition.array.begin.smithy
+
+        Error
+//      ^^^^^ entity.name.type.smithy
+
+    ]
+//  ^ punctuation.definition.array.end.smithy
+
+    rename: {
+//  ^^^^^^    support.type.property-name.smithy
+//        ^   punctuation.separator.dictionary.key-value.smithy
+//          ^ punctuation.definition.dictionary.begin.smithy
+
+        Foo: "Bar"
+//      ^^^        support.type.property-name.smithy
+//         ^       punctuation.separator.dictionary.key-value.smithy
+//           ^^^^^ string.quoted.double.smithy
+
+    }
+//  ^ punctuation.definition.dictionary.end.smithy
+
+}
+// <- punctuation.definition.dictionary.end.smithy
+
+operation Operation {
+// <---------         keyword.statement.smithy
+//        ^^^^^^^^^   entity.name.type.smithy
+//                  ^ punctuation.definition.dictionary.begin.smithy
+
+    input := {
+//  ^^^^^      support.type.property-name.smithy
+//        ^^   punctuation.separator.dictionary.inline-struct.smithy
+//           ^ punctuation.definition.dictionary.begin.smithy
+
+        foo: Bar
+//      ^^^      support.type.property-name.smithy
+//         ^     punctuation.separator.dictionary.key-value.smithy
+//           ^^^ entity.name.type.smithy
+
+        bar: Bar!
+//      ^^^       support.type.property-name.smithy
+//         ^      punctuation.separator.dictionary.key-value.smithy
+//           ^^^  entity.name.type.smithy
+// TODO         ^ keyword.operator.smithy
+
+        baz: Bar = default
+//      ^^^                support.type.property-name.smithy
+//         ^               punctuation.separator.dictionary.key-value.smithy
+//           ^^^           entity.name.type.smithy
+// TODO          ^         punctuation.separator.default.smithy
+// TODO            ^^^^^^^ keyword.other.smithy
+
+    }
+//  ^ punctuation.definition.dictionary.end.smithy
+
+    output: OperationOutput
+//  ^^^^^^                  support.type.property-name.smithy
+//        ^                 punctuation.separator.dictionary.key-value.smithy
+//          ^^^^^^^^^^^^^^^ entity.name.type.smithy
+
+    errors: [
+//  ^^^^^^    support.type.property-name.smithy
+//        ^   punctuation.separator.dictionary.key-value.smithy
+//          ^ punctuation.definition.array.begin.smithy
+
+        Error
+//      ^^^^^ entity.name.type.smithy
+
+    ]
+//  ^ punctuation.definition.array.end.smithy
+
+}
+// <- punctuation.definition.dictionary.end.smithy
+
+operation OtherOperation {
+// <---------              keyword.statement.smithy
+//        ^^^^^^^^^^^^^^   entity.name.type.smithy
+//                       ^ punctuation.definition.dictionary.begin.smithy
+
+    input := with Bar {}
+//  ^^^^^                support.type.property-name.smithy
+//        ^^             punctuation.separator.dictionary.inline-struct.smithy
+//           ^^^^        keyword.statement.with.smithy
+//                ^^^    entity.name.type.smithy
+//                    ^  punctuation.definition.dictionary.begin.smithy
+//                     ^ punctuation.definition.dictionary.end.smithy
+
+    output := @sensitive {}
+//  ^^^^^^                  support.type.property-name.smithy
+//         ^^               punctuation.separator.dictionary.inline-struct.smithy
+//            ^             punctuation.definition.annotation.smithy
+//             ^^^^^^^^^    storage.type.annotation.smithy
+//                       ^  punctuation.definition.dictionary.begin.smithy
+//                        ^ punctuation.definition.dictionary.end.smithy
+
+}
+// <- punctuation.definition.dictionary.end.smithy
+
+resource Resource {
+// <--------        keyword.statement.smithy
+//       ^^^^^^^^   entity.name.type.smithy
+//                ^ punctuation.definition.dictionary.begin.smithy
+
+    identifiers: {
+//  ^^^^^^^^^^^    support.type.property-name.smithy
+//             ^   punctuation.separator.dictionary.key-value.smithy
+//               ^ punctuation.definition.dictionary.begin.smithy
+
+        "id": String
+//      ^^^^         support.type.property-name.smithy
+//          ^        punctuation.separator.dictionary.key-value.smithy
+//            ^^^^^^ entity.name.type.smithy
+
+    }
+//  ^ punctuation.definition.dictionary.end.smithy
+
+    create: Create
+//  ^^^^^^         support.type.property-name.smithy
+//        ^        punctuation.separator.dictionary.key-value.smithy
+//          ^^^^^^ entity.name.type.smithy
+
+    put: Put
+//  ^^^      support.type.property-name.smithy
+//     ^     punctuation.separator.dictionary.key-value.smithy
+//       ^^^ entity.name.type.smithy
+
+    read: Read
+//  ^^^^       support.type.property-name.smithy
+//      ^      punctuation.separator.dictionary.key-value.smithy
+//        ^^^^ entity.name.type.smithy
+
+    update: Update
+//  ^^^^^^         support.type.property-name.smithy
+//        ^        punctuation.separator.dictionary.key-value.smithy
+//          ^^^^^^ entity.name.type.smithy
+
+    delete: Delete
+//  ^^^^^^         support.type.property-name.smithy
+//        ^        punctuation.separator.dictionary.key-value.smithy
+//          ^^^^^^ entity.name.type.smithy
+
+    list: List
+//  ^^^^       support.type.property-name.smithy
+//      ^      punctuation.separator.dictionary.key-value.smithy
+//        ^^^^ entity.name.type.smithy
+
+    operations: [
+//  ^^^^^^^^^^    support.type.property-name.smithy
+//            ^   punctuation.separator.dictionary.key-value.smithy
+//              ^ punctuation.definition.array.begin.smithy
+
+        Operation
+//      ^^^^^^^^^ entity.name.type.smithy
+
+    ]
+//  ^ punctuation.definition.array.end.smithy
+
+    collectionOperations: [
+//  ^^^^^^^^^^^^^^^^^^^^    support.type.property-name.smithy
+//                      ^   punctuation.separator.dictionary.key-value.smithy
+//                        ^ punctuation.definition.array.begin.smithy
+
+        CollectionOperation
+//      ^^^^^^^^^^^^^^^^^^^ entity.name.type.smithy
+
+    ]
+//  ^ punctuation.definition.array.end.smithy
+
+    resources: [
+//  ^^^^^^^^^    support.type.property-name.smithy
+//           ^   punctuation.separator.dictionary.key-value.smithy
+//             ^ punctuation.definition.array.begin.smithy
+
+        SubResource
+//      ^^^^^^^^^^^ entity.name.type.smithy
+
+    ]
+//  ^ punctuation.definition.array.end.smithy
+
+}
+// <- punctuation.definition.dictionary.end.smithy

--- a/tests/simple-shapes.smithy
+++ b/tests/simple-shapes.smithy
@@ -1,0 +1,56 @@
+// SYNTAX TEST "source.smithy" "This tests simple shapes"
+$version: "2.0"
+
+namespace com.example
+
+blob Blob
+// <----  keyword.statement.smithy
+//   ^^^^ entity.name.type.smithy
+
+boolean Bool
+// <-------  keyword.statement.smithy
+//      ^^^^ entity.name.type.smithy
+
+string String
+// <------    keyword.statement.smithy
+//     ^^^^^^ entity.name.type.smithy
+
+byte Byte
+// <----  keyword.statement.smithy
+//   ^^^^ entity.name.type.smithy
+
+short Short
+// <-----   keyword.statement.smithy
+//    ^^^^^ entity.name.type.smithy
+
+integer Integer
+// <-------     keyword.statement.smithy
+//      ^^^^^^^ entity.name.type.smithy
+
+long Long
+// <----  keyword.statement.smithy
+//   ^^^^ entity.name.type.smithy
+
+float Float
+// <-----   keyword.statement.smithy
+//    ^^^^^ entity.name.type.smithy
+
+double Double
+// <------    keyword.statement.smithy
+//     ^^^^^^ entity.name.type.smithy
+
+bigInteger BigInt
+// <----------    keyword.statement.smithy
+//         ^^^^^^ entity.name.type.smithy
+
+bigDecimal BigDecimal
+// <----------        keyword.statement.smithy
+//         ^^^^^^^^^^ entity.name.type.smithy
+
+timestamp Timestamp
+// <---------       keyword.statement.smithy
+//        ^^^^^^^^^ entity.name.type.smithy
+
+document Document
+// <--------      keyword.statement.smithy
+//       ^^^^^^^^ entity.name.type.smithy

--- a/tests/traits.smithy
+++ b/tests/traits.smithy
@@ -1,0 +1,29 @@
+// SYNTAX TEST "source.smithy" "This tests traits"
+$version: "2.0"
+
+namespace com.example
+
+@foo
+// <-    punctuation.definition.annotation.smithy
+// <~--- storage.type.annotation.smithy
+
+@bar()
+// <-    punctuation.definition.annotation.smithy
+// <~--- storage.type.annotation.smithy
+//  ^    punctuation.definition.dictionary.begin.smithy
+//   ^   punctuation.definition.dictionary.end.smithy
+
+@baz(400)
+// <-     punctuation.definition.annotation.smithy
+// <~---  storage.type.annotation.smithy
+//  ^     punctuation.definition.dictionary.begin.smithy
+//   ^^^  constant.numeric.smithy
+//      ^ punctuation.definition.dictionary.end.smithy
+
+string Foo
+
+apply Foo @mixin
+// <-----        keyword.statement.smithy
+//    ^^^        entity.name.type.smithy
+//        ^      punctuation.definition.annotation.smithy
+//         ^^^^^ storage.type.annotation.smithy

--- a/tests/use.smithy
+++ b/tests/use.smithy
@@ -1,0 +1,8 @@
+// SYNTAX TEST "source.smithy" "This tests the use section"
+$version: "2.0"
+
+namespace com.example
+
+use com.example.foo#Bar
+// <---                 keyword.statement.smithy
+//  ^^^^^^^^^^^^^^^^^^^ entity.name.type.smithy


### PR DESCRIPTION
This adds support for some of the new idl syntax for 2.0. Namely it adds
support for:

* optional commas
* inline structure definitions
* the required syntax sugar (e.g. trailing `!`)
* the proposed default syntax sugar (e.g. trailing `= default`)
* mixins via the `with` statement

I do not think it is possible for a TextMate grammar to be able to distinguish
between a key and a value in every case when there are no pair separators,
though I would love to be proven wrong on this.

TM grammars are regex-based, but crucially regexes can never match across
lines. A regex with a newline in the middle, like `foo\nbar` will  NEVER match.
This is to allow the highlighter to be able to re-start at any line if parsing
failed on a previous line. To work around this somewhat, they allow you to
change states with `begin` and `end`  regexes. Since these state changes are
*regexes* and regexes can't span lines, you can't have a complex end state. So
you can't simply say "end after parsing a json-like value".  Since we have no
other indication that a pair is ended, we can't end a pair state if we enter
one.

For some context, the way the JSON TM grammar works is by having an effective
"value" state which is started by `:` and ended by `,` or `}`. This is what we
used to do.

Now what we CAN do if we don't care about being 100% accurate in all cases, is
try to match the key if it shares a line with the colon. This is the approach
I've gone with since I'm willing to bet this will be the case most of the time.

![Screenshot 2021-11-08 at 18 38 37](https://user-images.githubusercontent.com/2643092/140791047-47dbadf9-8755-44f0-99ed-81751afc449e.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
