### PR TITLE
Upgrade engine and dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,19 @@
             "version": "0.3.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "vscode-nls": "^3.2.4",
+                "vscode-nls": "^5.0.0",
                 "vscode-tmgrammar-test": "^0.0.11"
             },
             "devDependencies": {
-                "@types/node": "^10.12.12",
-                "@types/vscode": "^1.32.0",
-                "typescript": "^3.1.3",
+                "@types/node": "^17.0.23",
+                "@types/vscode": "^1.65.0",
+                "typescript": "^4.6.3",
                 "vsce": "^2.7.0",
                 "vscode-nls-dev": "^4.0.0",
-                "vscode-test": "^1.4.0"
+                "vscode-test": "^1.6.1"
             },
             "engines": {
-                "vscode": "^1.32.0"
+                "vscode": "^1.65.0"
             }
         },
         "node_modules/@tootallnate/once": {
@@ -34,15 +34,15 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "10.17.60",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-            "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+            "version": "17.0.23",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+            "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.61.0.tgz",
-            "integrity": "sha512-9k5Nwq45hkRwdfCFY+eKXeQQSbPoA114mF7U/4uJXRBJeGIO7MuJdhF1PnaDN+lllL9iKGQtd6FFXShBXMNaFg==",
+            "version": "1.65.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
+            "integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
             "dev": true
         },
         "node_modules/agent-base": {
@@ -1803,9 +1803,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "3.9.10",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-            "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -1909,9 +1909,9 @@
             }
         },
         "node_modules/vscode-nls": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-3.2.5.tgz",
-            "integrity": "sha512-ITtoh3V4AkWXMmp3TB97vsMaHRgHhsSFPsUdzlueSL+dRZbSNTZeOmdQv60kjCV306ghPxhDeoNUEm3+EZMuyw=="
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz",
+            "integrity": "sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA=="
         },
         "node_modules/vscode-nls-dev": {
             "version": "4.0.0",
@@ -1934,19 +1934,6 @@
             },
             "bin": {
                 "vscl": "lib/vscl.js"
-            }
-        },
-        "node_modules/vscode-nls-dev/node_modules/typescript": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-            "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
-            "dev": true,
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=4.2.0"
             }
         },
         "node_modules/vscode-oniguruma": {
@@ -2240,15 +2227,15 @@
             "dev": true
         },
         "@types/node": {
-            "version": "10.17.60",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-            "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+            "version": "17.0.23",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+            "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.61.0.tgz",
-            "integrity": "sha512-9k5Nwq45hkRwdfCFY+eKXeQQSbPoA114mF7U/4uJXRBJeGIO7MuJdhF1PnaDN+lllL9iKGQtd6FFXShBXMNaFg==",
+            "version": "1.65.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
+            "integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
             "dev": true
         },
         "agent-base": {
@@ -3626,9 +3613,9 @@
             }
         },
         "typescript": {
-            "version": "3.9.10",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-            "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
             "dev": true
         },
         "uc.micro": {
@@ -3716,9 +3703,9 @@
             }
         },
         "vscode-nls": {
-            "version": "3.2.5",
-            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-3.2.5.tgz",
-            "integrity": "sha512-ITtoh3V4AkWXMmp3TB97vsMaHRgHhsSFPsUdzlueSL+dRZbSNTZeOmdQv60kjCV306ghPxhDeoNUEm3+EZMuyw=="
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz",
+            "integrity": "sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA=="
         },
         "vscode-nls-dev": {
             "version": "4.0.0",
@@ -3738,14 +3725,6 @@
                 "vinyl": "^2.2.1",
                 "xml2js": "^0.4.23",
                 "yargs": "^17.3.0"
-            },
-            "dependencies": {
-                "typescript": {
-                    "version": "4.6.2",
-                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-                    "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
-                    "dev": true
-                }
             }
         },
         "vscode-oniguruma": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "0.3.0",
     "publisher": "aws-smithy",
     "engines": {
-        "vscode": "^1.32.0"
+        "vscode": "^1.65.0"
     },
     "repository": {
         "type": "git",
@@ -39,19 +39,20 @@
         ]
     },
     "scripts": {
-        "install-plugin": "vsce package -o smithy-vscode-test.vsix && code --install-extension smithy-vscode-test.vsix",
+        "install-plugin": "npm run package && code --install-extension smithy-vscode-test.vsix",
+        "package": "vsce package -o smithy-vscode-test.vsix",
         "test": "npx vscode-tmgrammar-test -s 'source.smithy' -g syntaxes/smithy.tmLanguage -t 'tests/*'"
     },
     "devDependencies": {
-        "@types/node": "^10.12.12",
-        "@types/vscode": "^1.32.0",
-        "typescript": "^3.1.3",
+        "@types/node": "^17.0.23",
+        "@types/vscode": "^1.65.0",
+        "typescript": "^4.6.3",
         "vsce": "^2.7.0",
         "vscode-nls-dev": "^4.0.0",
-        "vscode-test": "^1.4.0"
+        "vscode-test": "^1.6.1"
     },
     "dependencies": {
-        "vscode-nls": "^3.2.4",
+        "vscode-nls": "^5.0.0",
         "vscode-tmgrammar-test": "^0.0.11"
     }
 }


### PR DESCRIPTION
Upgrades vscode engine and dependencies. Splits out vsce `package` command so that it can be run separately from the `intsll-plugin` command to install to VS Code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
