### PR TITLE
Setup launch config for debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,8 +11,11 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
-                "--extensionDevelopmentPath=${workspaceFolder}"
-            ]
+                "--disable-extensions",
+                "--extensionDevelopmentPath=${workspaceFolder}",
+                "--extensionTestsPath=${workspaceFolder}/out/suite"
+            ],
+            "outFiles": ["${workspaceFolder}/out/suite/*.js"]
         }
     ]
 }


### PR DESCRIPTION
Adds tests path and disables other extensions, allowing for debugging the extension integration tests via `Run and Debug` pane in VS Code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
