### PR TITLE
[DRAFT] Smithy Language Server integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 **/.DS_Store
 .idea
 telemetryCache
+.smithy.lsp.log

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,13 +9,15 @@
             "name": "Extension",
             "type": "extensionHost",
             "request": "launch",
+            "preLaunchTask": "compile",
             "runtimeExecutable": "${execPath}",
             "args": [
                 "--disable-extensions",
-                "--extensionDevelopmentPath=${workspaceFolder}",
-                "--extensionTestsPath=${workspaceFolder}/out/suite"
+                "--extensionDevelopmentPath=${workspaceRoot}",
+                "--extensionTestsPath=${workspaceRoot}/out/tests/suite",
+                "${workspaceRoot}/test-fixture",
             ],
-            "outFiles": ["${workspaceFolder}/out/suite/*.js"]
+            "outFiles": ["${workspaceRoot}/out/tests/suite/*.js"]
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "compile",
+        "command": "npm",
+        "args": ["run", "compile"]
+      }
+    ]
+  }

--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ Additionally, it provides [Snippets](https://code.visualstudio.com/docs/editor/u
 
 ### VS Code
 
-This extension is not yet published, so you will need to install it manually.
-First, clone and change into this repository: `git clone https://github.com/awslabs/smithy-vscode.git && cd smithy-vscode`
-Then, run npm commands to install:
+This extension and the Smithy Language Server are not yet published. To use this extension, publish the Language Server locally before manually installing the Extension with the following steps:
+* Clone the Language Server locally: `git clone https://github.com/awslabs/smithy-language-server.git && cd smithy-language-server`
+* Build and publish it locally: `./gradlew build publishToMavenLocal`
+* Clone the Extension: `git clone https://github.com/awslabs/smithy-vscode.git && cd smithy-vscode`
+* Run npm commands to install:
 `npm install && npm run install-plugin`
 
 ### IntelliJ

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,14 @@
       "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "test-extension": "^0.0.1",
+        "vscode-languageclient": "^7.0.0",
         "vscode-nls": "^5.0.0",
         "vscode-tmgrammar-test": "^0.0.11"
       },
       "devDependencies": {
+        "@types/follow-redirects": "^1.14.1",
         "@types/glob": "^7.2.0",
         "@types/mocha": "^9.1.0",
         "@types/node": "^17.0.23",
@@ -36,6 +40,15 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@types/follow-redirects": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@types/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-THBEFwqsLuU/K62B5JRwab9NW97cFmL4Iy34NTMX0bMycQVzq2q7PKOkhfivIwxdpa/J72RppgC42vCHfwKJ0Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/glob": {
@@ -930,6 +943,25 @@
       "dev": true,
       "bin": {
         "flat": "cli.js"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/from": {
@@ -2439,6 +2471,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/test-extension": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/test-extension/-/test-extension-0.0.1.tgz",
+      "integrity": "sha512-ieDVxU9WqPd5W6caypXJhaGSnCQURU0RZO/5WNDV4CFpOuK5RC8SKIiQdQE/66NXNWF3k/YQTdtc6RjotpsSTA==",
+      "engines": {
+        "vscode": "^1.60.0"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -2627,6 +2667,63 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+      "engines": {
+        "node": ">=8.0.0 || >=10.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
+      "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+      "dependencies": {
+        "minimatch": "^3.0.4",
+        "semver": "^7.3.4",
+        "vscode-languageserver-protocol": "3.16.0"
+      },
+      "engines": {
+        "vscode": "^1.52.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/lru-cache": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.0.tgz",
+      "integrity": "sha512-AmXqneQZL3KZMIgBpaPTeI6pfwh+xQ2vutMsyqOu1TBdEXFZgpG/80wuJ531w2ZN7TI0/oc8CPxzh/DKQudZqg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/semver": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+      "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+      "dependencies": {
+        "lru-cache": "^7.4.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "dependencies": {
+        "vscode-jsonrpc": "6.0.0",
+        "vscode-languageserver-types": "3.16.0"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
     },
     "node_modules/vscode-nls": {
       "version": "5.0.0",
@@ -2978,6 +3075,15 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
+    },
+    "@types/follow-redirects": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@types/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-THBEFwqsLuU/K62B5JRwab9NW97cFmL4Iy34NTMX0bMycQVzq2q7PKOkhfivIwxdpa/J72RppgC42vCHfwKJ0Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/glob": {
       "version": "7.2.0",
@@ -3661,6 +3767,11 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "from": {
       "version": "0.1.7",
@@ -4797,6 +4908,11 @@
         }
       }
     },
+    "test-extension": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/test-extension/-/test-extension-0.0.1.tgz",
+      "integrity": "sha512-ieDVxU9WqPd5W6caypXJhaGSnCQURU0RZO/5WNDV4CFpOuK5RC8SKIiQdQE/66NXNWF3k/YQTdtc6RjotpsSTA=="
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -4954,6 +5070,50 @@
         "yauzl": "^2.3.1",
         "yazl": "^2.2.2"
       }
+    },
+    "vscode-jsonrpc": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
+    },
+    "vscode-languageclient": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
+      "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+      "requires": {
+        "minimatch": "^3.0.4",
+        "semver": "^7.3.4",
+        "vscode-languageserver-protocol": "3.16.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "7.8.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.0.tgz",
+          "integrity": "sha512-AmXqneQZL3KZMIgBpaPTeI6pfwh+xQ2vutMsyqOu1TBdEXFZgpG/80wuJ531w2ZN7TI0/oc8CPxzh/DKQudZqg=="
+        },
+        "semver": {
+          "version": "7.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+          "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+          "requires": {
+            "lru-cache": "^7.4.0"
+          }
+        }
+      }
+    },
+    "vscode-languageserver-protocol": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "requires": {
+        "vscode-jsonrpc": "6.0.0",
+        "vscode-languageserver-types": "3.16.0"
+      }
+    },
+    "vscode-languageserver-types": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
     },
     "vscode-nls": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "scripts": {
     "compile": "tsc -p ./",
     "install-plugin": "npm run package && code --install-extension smithy-vscode-test.vsix",
-    "package": "vsce package -o smithy-vscode-test.vsix",
+    "package": "npm run compile && vsce package -o smithy-vscode-test.vsix",
     "format": "prettier --write '**/*.{ts,js,json,yml}'",
     "format-check": "prettier --check '**/*.{ts,js,json,yml}'",
     "test-grammar": "npx vscode-tmgrammar-test -s 'source.smithy' -g syntaxes/smithy.tmLanguage -t 'tests/grammar/*'",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:awslabs/smithy-vscode.git"
+    "url": "https://github.com/awslabs/smithy-vscode.git"
   },
   "license": "Apache-2.0",
   "prettier": {
@@ -20,6 +20,10 @@
     "Programming Languages",
     "Snippets"
   ],
+  "activationEvents": [
+    "onLanguage:smithy"
+  ],
+  "main": "./out/src/extension",
   "preview": true,
   "contributes": {
     "languages": [
@@ -47,18 +51,49 @@
         "language": "smithy",
         "path": "./snippets.json"
       }
-    ]
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "vscode-smithy configuration",
+      "properties": {
+        "smithyLsp.maxNumberOfProblems": {
+          "scope": "resource",
+          "type": "number",
+          "default": 100,
+          "description": "Controls the maximum number of problems produced by the server."
+        },
+        "smithyLsp.trace.server": {
+          "scope": "window",
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "verbose",
+          "description": "Traces the communication between VS Code and the language server."
+        },
+        "smithyLsp.version": {
+          "scope": "window",
+          "type": "string",
+          "default": "0.0.0-snapshot",
+          "description": "Version of the Smithy LSP (see https://github.com/smithy/smithy-language-server)"
+        }
+      }
+    }
   },
   "scripts": {
+    "compile": "tsc -p ./",
     "install-plugin": "npm run package && code --install-extension smithy-vscode-test.vsix",
     "package": "vsce package -o smithy-vscode-test.vsix",
     "format": "prettier --write '**/*.{ts,js,json,yml}'",
     "format-check": "prettier --check '**/*.{ts,js,json,yml}'",
     "test-grammar": "npx vscode-tmgrammar-test -s 'source.smithy' -g syntaxes/smithy.tmLanguage -t 'tests/grammar/*'",
-    "test-extension": "tsc -p ./ && node ./out/runTest.js",
+    "test-extension": "tsc -p ./ && node ./out/tests/runTest.js",
     "test": "npm run format-check && npm run test-grammar && npm run test-extension"
   },
   "devDependencies": {
+    "@types/follow-redirects": "^1.14.1",
     "@types/glob": "^7.2.0",
     "@types/mocha": "^9.1.0",
     "@types/node": "^17.0.23",
@@ -72,6 +107,9 @@
     "vscode-nls-dev": "^4.0.0"
   },
   "dependencies": {
+    "follow-redirects": "^1.14.9",
+    "test-extension": "^0.0.1",
+    "vscode-languageclient": "^7.0.0",
     "vscode-nls": "^5.0.0",
     "vscode-tmgrammar-test": "^0.0.11"
   }

--- a/src/coursier/coursier.ts
+++ b/src/coursier/coursier.ts
@@ -1,0 +1,12 @@
+import { downloadCoursierIfRequired } from "./download-coursier";
+import { findCoursierOnPath } from "./path-check";
+
+export function getCoursierExecutable(extensionPath: string): Promise<string> {
+  return findCoursierOnPath(extensionPath).then((paths) => {
+    if (paths.length > 0) {
+      return paths[0];
+    } else {
+      return downloadCoursierIfRequired(extensionPath, "v2.0.6");
+    }
+  });
+}

--- a/src/coursier/download-coursier.ts
+++ b/src/coursier/download-coursier.ts
@@ -1,0 +1,99 @@
+import * as path from "path";
+import { https } from "follow-redirects";
+import { IncomingMessage } from "http";
+import * as fs from "fs";
+import { access, mkdir } from "fs/promises";
+
+export function downloadCoursierIfRequired(
+  extensionPath: string,
+  versionPath: string
+): Promise<string> {
+  function binPath(filename: string) {
+    return path.join(extensionPath, filename);
+  }
+
+  function createDir() {
+    return mkdir(extensionPath).catch((err: { code?: string }) => {
+      return err && err.code === "EEXIST"
+        ? Promise.resolve()
+        : Promise.reject(err);
+    });
+  }
+
+  const urls = {
+    darwin: `https://github.com/coursier/coursier/releases/download/${versionPath}/cs-x86_64-apple-darwin`,
+    linux: `https://github.com/coursier/coursier/releases/download/${versionPath}/cs-x86_64-pc-linux`,
+    win32: `https://github.com/coursier/coursier/releases/download/${versionPath}/cs-x86_64-pc-win32.exe`,
+  };
+  const targets = {
+    darwin: binPath("coursier"),
+    linux: binPath("coursier"),
+    win32: binPath("coursier.exe"),
+  };
+
+  const targetFile = targets[process.platform];
+  return validBinFileExists(targetFile).then((valid) => {
+    return valid
+      ? targetFile
+      : createDir().then(() =>
+          downloadFile(urls[process.platform], targetFile)
+        );
+  });
+}
+
+function validBinFileExists(file: string): Promise<boolean> {
+  return access(file, fs.constants.X_OK)
+    .then(() => true)
+    .catch(() => false);
+}
+
+function downloadFile(url: string, targetFile: string): Promise<string> {
+  function promiseGet(url: string): Promise<IncomingMessage> {
+    return new Promise((resolve, reject) => {
+      https.get(url, (response) => {
+        if (response.statusCode === 200) {
+          resolve(response);
+        } else {
+          reject(
+            new Error(
+              `Server responded with ${response.statusCode}: ${response.statusMessage}`
+            )
+          );
+        }
+      });
+    });
+  }
+
+  function writeToDisk(response: IncomingMessage): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const file = fs.createWriteStream(targetFile, {
+        flags: "wx",
+        mode: 0o755,
+      });
+      response.pipe(file);
+
+      file.on("finish", () => {
+        console.log(`Finished downloaded file at ${targetFile}`);
+        resolve(targetFile);
+      });
+
+      file.on("error", (err: { code: string | undefined }) => {
+        if (file) {
+          file.close();
+          fs.unlink(targetFile, () => {}); // Delete temp file
+        }
+
+        if (err.code === "EEXIST") {
+          console.log(`File already exists at ${targetFile}`);
+          resolve(targetFile);
+        } else {
+          console.error(`File error while downloading file at ${targetFile}`);
+          console.error(err);
+          reject(err);
+        }
+      });
+    });
+  }
+  // adapted from https://stackoverflow.com/a/45007624
+  return promiseGet(url).then((resp) => writeToDisk(resp));
+}

--- a/src/coursier/path-check.ts
+++ b/src/coursier/path-check.ts
@@ -1,0 +1,44 @@
+import { spawn } from "child_process";
+
+/**
+ * This type is used to bypass the `defaultImpl` when running the tests.
+ */
+export type ExecForCode = {
+  run: (execName: string, args: Array<string>, cwd: string) => Promise<number>;
+};
+
+const defaultImpl: ExecForCode = {
+  run: (execName: string, args: Array<string>, cwd: string) => {
+    return new Promise((resolve, reject) => {
+      const options = { cwd };
+      const resolveProcess = spawn(execName, args, options);
+      resolveProcess.on("exit", (exitCode) => {
+        resolve(exitCode);
+      });
+      resolveProcess.on("error", (err) => {
+        reject(err);
+      });
+    });
+  },
+};
+
+export function findCoursierOnPath(
+  cwd: string,
+  execForCode: ExecForCode = defaultImpl
+): Promise<Array<string>> {
+  function availableOnPath(execName: string): Promise<boolean> {
+    return execForCode
+      .run(execName, ["--help"], cwd)
+      .then((ec) => ec === 0)
+      .catch(() => false);
+  }
+
+  const possibleCoursierNames = ["cs", "coursier"];
+  return possibleCoursierNames.reduce((accP, current) => {
+    return accP.then((acc) => {
+      return availableOnPath(current).then((succeeeded) => {
+        return succeeeded ? [...acc, current] : acc;
+      });
+    });
+  }, Promise.resolve([]));
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,190 @@
+import * as net from "net";
+import * as fs from "fs";
+import * as child_process from "child_process";
+import { workspace, ExtensionContext } from "vscode";
+import * as vscode from "vscode";
+
+import {
+  CancellationToken,
+  LanguageClient,
+  LanguageClientOptions,
+  RequestType,
+  StreamInfo,
+  TextDocumentIdentifier,
+} from "vscode-languageclient/node";
+import { getCoursierExecutable } from "./coursier/coursier";
+
+let client: LanguageClient;
+
+export function activate(context: ExtensionContext) {
+  async function createServer(): Promise<StreamInfo> {
+    function startServer(executable: string): Promise<StreamInfo> {
+      console.log(`Executable located at ${executable}.`);
+      return new Promise((resolve, reject) => {
+        const server = net
+          .createServer((socket) => {
+            console.log("Creating server");
+
+            resolve({
+              reader: socket,
+              writer: socket,
+            });
+
+            socket.on("end", () => console.log("Disconnected"));
+          })
+          .on("error", (err) => {
+            // handle errors here
+            reject(err);
+          });
+
+        // grab a random port.
+        server.listen(() => {
+          // Start the child java process
+          let options = { cwd: context.extensionPath };
+
+          let port = (server.address() as net.AddressInfo).port;
+
+          let version = vscode.workspace
+            .getConfiguration("smithyLsp")
+            .get("version", "`");
+
+          // Downloading latest poms
+          let resolveArgs = [
+            "resolve",
+            "--mode",
+            "force",
+            "software.amazon.smithy:smithy-language-server:" + version,
+            "-r",
+            "m2local",
+          ];
+          let resolveProcess = child_process.spawn(
+            executable,
+            resolveArgs,
+            options
+          );
+          console.log(resolveArgs);
+          resolveProcess.on("exit", (exitCode) => {
+            console.log("Exit code : " + exitCode);
+            if (exitCode == 0) {
+              console.log(
+                "Launching smithy-language-server version:" + version
+              );
+
+              let launchargs = [
+                "launch",
+                "software.amazon.smithy:smithy-language-server:" + version,
+                "-r",
+                "m2local",
+                "--",
+                port.toString(),
+              ];
+
+              console.log(launchargs);
+
+              let childProcess = child_process.spawn(
+                executable,
+                launchargs,
+                options
+              );
+
+              childProcess.stdout.on("data", (data) => {
+                console.log(`stdout: ${data}`);
+              });
+
+              childProcess.stderr.on("data", (data) => {
+                console.error(`stderr: ${data}`);
+              });
+
+              childProcess.on("close", (code) => {
+                console.log(`LSP exited with code ${code}`);
+              });
+            } else {
+              console.log(
+                `Could not resolve smithy-language-server implementation`
+              );
+            }
+          });
+
+          // Send raw output to a file
+          if (context.storageUri) {
+            if (!fs.existsSync(context.storageUri.fsPath)) {
+              fs.mkdirSync(context.storageUri.fsPath);
+            }
+          }
+        });
+      });
+    }
+
+    const binaryPath = await getCoursierExecutable(context.globalStoragePath);
+    return await startServer(binaryPath);
+  }
+
+  // Options to control the language client
+  let clientOptions: LanguageClientOptions = {
+    // Register the server for plain text documents
+    documentSelector: [
+      { scheme: "file", language: "smithy" },
+      { scheme: "smithyjar", language: "smithy" },
+    ],
+    synchronize: {
+      // Notify the server about file changes to 'smithy-build.json' files contained in the workspace
+      fileEvents: workspace.createFileSystemWatcher("**/{smithy-build}.json"),
+    },
+    outputChannelName: "Smithy Language Server",
+  };
+
+  // Create the language client and start the client.
+
+  client = new LanguageClient(
+    "smithyLsp",
+    "Smithy LSP",
+    createServer,
+    clientOptions
+  );
+  const smithyContentProvider = createSmithyContentProvider(client);
+  context.subscriptions.push(
+    workspace.registerTextDocumentContentProvider(
+      "smithyjar",
+      smithyContentProvider
+    )
+  );
+
+  // Start the client. This will also launch the server
+  client.start();
+}
+
+export function deactivate(): Thenable<void> | undefined {
+  if (!client) {
+    return undefined;
+  }
+  return client.stop();
+}
+
+function createSmithyContentProvider(
+  languageClient: LanguageClient
+): vscode.TextDocumentContentProvider {
+  return <vscode.TextDocumentContentProvider>{
+    provideTextDocumentContent: async (
+      uri: vscode.Uri,
+      token: CancellationToken
+    ): Promise<string> => {
+      return languageClient
+        .sendRequest(
+          ClassFileContentsRequest.type,
+          { uri: uri.toString() },
+          token
+        )
+        .then((v: string): string => {
+          return v || "";
+        });
+    },
+  };
+}
+
+export namespace ClassFileContentsRequest {
+  export const type = new RequestType<
+    TextDocumentIdentifier,
+    string,
+    void
+  >("smithy/jarFileContents");
+}

--- a/test-fixture/main.smithy
+++ b/test-fixture/main.smithy
@@ -1,3 +1,5 @@
+$version: "1.0"
+
 namespace example.weather
 
 /// Provides weather forecasts.
@@ -13,6 +15,7 @@ resource City {
     identifiers: { cityId: CityId },
     read: GetCity,
     list: ListCities,
+    delete: DeleteCity,
     resources: [Forecast],
 }
 

--- a/test-fixture/smithy-build.json
+++ b/test-fixture/smithy-build.json
@@ -1,0 +1,6 @@
+{
+  "maven": {
+    "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.19.0"],
+    "repositories": [{ "url": "" }]
+  }
+}

--- a/tests/runTest.ts
+++ b/tests/runTest.ts
@@ -4,9 +4,9 @@ import { runTests } from "@vscode/test-electron";
 
 async function go() {
   try {
-    const extensionDevelopmentPath = path.resolve(__dirname, "../");
+    const extensionDevelopmentPath = path.resolve(__dirname, "../../");
     const extensionTestsPath = path.resolve(__dirname, "./suite");
-    const testWorkspace = path.resolve(__dirname, "../test-fixture");
+    const testWorkspace = path.resolve(__dirname, "../../test-fixture");
 
     await runTests({
       extensionDevelopmentPath,
@@ -15,6 +15,7 @@ async function go() {
     });
   } catch (err) {
     console.error("Failed to run tests");
+    console.log(err);
     process.exit(1);
   }
 }

--- a/tests/suite/extension.test.ts
+++ b/tests/suite/extension.test.ts
@@ -3,22 +3,47 @@ import * as vscode from "vscode";
 import { getDocUri } from "./helper";
 
 suite("Extension tests", () => {
-  test("Should start extension", async () => {
+  test("Should start extension and Language Server", async () => {
     const smithyMainUri = getDocUri("main.smithy");
-
     const doc = await vscode.workspace.openTextDocument(smithyMainUri);
     const editor = await vscode.window.showTextDocument(doc);
     const ext = vscode.extensions.getExtension("aws-smithy.smithy-vscode");
-    await ext.activate();
+    await waitForServerStartup();
+
+    // Grab Language Server logs
+    const smithyLogUri = getDocUri(".smithy.lsp.log");
+    const smithyLog = await vscode.workspace.openTextDocument(smithyLogUri);
+    const logText = smithyLog.getText();
 
     assert.notEqual(doc, undefined);
     assert.notEqual(editor, undefined);
     assert.equal(ext.isActive, true);
-  });
+    assert.match(logText, /Downloaded external jars.*smithy-aws-traits-1\.19\.0\.jar/);
+    assert.match(logText, /Discovered smithy files.*test-fixture\/main.smithy]/);
+
+    const diagnostics = vscode.languages.getDiagnostics(smithyMainUri);
+    console.log(diagnostics.length);
+  }).timeout(7000);
 
   test("Should register language", async () => {
     const languages = await vscode.languages.getLanguages();
-
     assert.equal(languages.includes("smithy"), true);
   });
+
+  test("Should provide diagnostics", async () => {
+    const smithyMainUri = getDocUri("main.smithy");
+    const doc = await vscode.workspace.openTextDocument(smithyMainUri);
+    const editor = await vscode.window.showTextDocument(doc);
+    await waitForServerStartup();
+    const diagnostics = vscode.languages.getDiagnostics(smithyMainUri);
+
+    assert.match(diagnostics[0].message, /relationship to an unresolved shape `example.weather#DeleteCity`/);
+    assert.equal(diagnostics[0].range.start.line, 13);
+    assert.equal(diagnostics[0].range.start.character, 0);
+  }).timeout(7000);
+
+  async function waitForServerStartup() {
+    // Wait for Smithy Language Server to start
+    await new Promise(resolve => setTimeout(resolve, 6000));
+  }
 });

--- a/tests/suite/helper.ts
+++ b/tests/suite/helper.ts
@@ -5,7 +5,7 @@ export let doc: vscode.TextDocument;
 export let editor: vscode.TextEditor;
 
 export const getDocPath = (p: string) => {
-  return path.resolve(__dirname, "../../test-fixture", p);
+  return path.resolve(__dirname, "../../../test-fixture", p);
 };
 
 export const getDocUri = (p: string) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,6 @@
     "sourceMap": true,
     "skipLibCheck": true
   },
-  "include": ["tests"],
+  "include": ["src", "tests"],
   "exclude": ["node_modules", ".vscode-test"]
 }


### PR DESCRIPTION
[DRAFT] This PR integrates the extension to begin using the [Smithy Language Server](https://github.com/awslabs/smithy-language-server/).

The contents of `src/extension.ts` and `src/coursier/` are borrowed from [Disney's Smithy VSCode Extension](https://github.com/disneystreaming/vscode-smithy), which uses Coursier to bootstrap the Smithy Language Server and resolve model dependencies specified in a workspace's `smithy-build.json`.

The PR also adds integration tests which check the extension launches the Smithy Language Server successfully, resolves model dependencies, and uses the Smithy Language Server to provide diagnostics.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
