### PR TITLE
Fix launching LSP on case-sensitive platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
         "smithyLsp.version": {
           "scope": "window",
           "type": "string",
-          "default": "0.0.0-snapshot",
+          "default": "0.0.0-SNAPSHOT",
           "description": "Version of the Smithy LSP (see https://github.com/smithy/smithy-language-server)"
         }
       }


### PR DESCRIPTION
The Smithy Language Server uses the version `0.0.0-SNAPSHOT`. This updates package.json to set the correctly cased `SNAPSHOT`, fixing the extension being able to launch the Language Server on case-sensitive platforms.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
