### PR TITLE
Fetch test dependencies from Maven Central

### DIFF
--- a/test-fixtures/suite1/smithy-build.json
+++ b/test-fixtures/suite1/smithy-build.json
@@ -1,6 +1,6 @@
 {
   "maven": {
     "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.19.0"],
-    "repositories": [{ "url": "" }]
+    "repositories": [{ "url": "https://repo1.maven.org/maven2/" }]
   }
 }

--- a/test-fixtures/suite2/smithy-build.json
+++ b/test-fixtures/suite2/smithy-build.json
@@ -1,6 +1,6 @@
 {
   "maven": {
     "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.19.0"],
-    "repositories": [{ "url": "" }]
+    "repositories": [{ "url": "https://repo1.maven.org/maven2/" }]
   }
 }

--- a/test-fixtures/suite3/smithy-build.json
+++ b/test-fixtures/suite3/smithy-build.json
@@ -1,6 +1,6 @@
 {
   "maven": {
     "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.19.0"],
-    "repositories": [{ "url": "" }]
+    "repositories": [{ "url": "https://repo1.maven.org/maven2/" }]
   }
 }


### PR DESCRIPTION
This updates the test-fixtures to use the Maven Central repository for fetching the dependency artifacts use by the extension when launching the Smithy Language Server.

Previously these tests would only pass if the dependency artifacts were cached locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
