### PR TITLE
Use version 0.1.0 of the Smithy Language Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,8 @@ Additionally, it provides [Snippets](https://code.visualstudio.com/docs/editor/u
 
 ### VS Code
 
-This extension and the Smithy Language Server are not yet published. To use
-this extension, publish the Language Server locally before manually installing
+This extension is not yet published. To use this extension, manually installing
 the Extension with the following steps:
-* Clone the Language Server locally:
-`git clone https://github.com/awslabs/smithy-language-server.git && cd smithy-language-server`
-* Build and publish it locally: `./gradlew build publishToMavenLocal`
 * Clone the Extension: `git clone https://github.com/awslabs/smithy-vscode.git && cd smithy-vscode`
 * Run npm commands to install:
 `npm install && npm run install-plugin`

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
         "smithyLsp.version": {
           "scope": "window",
           "type": "string",
-          "default": "0.0.0-SNAPSHOT",
+          "default": "0.1.0",
           "description": "Version of the Smithy LSP (see https://github.com/smithy/smithy-language-server)"
         }
       }

--- a/tests/runTest.ts
+++ b/tests/runTest.ts
@@ -38,7 +38,7 @@ async function go() {
     const vscodeExecutablePath = await downloadAndUnzipVSCode();
     const [cli, ...args] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
 
-    const result = spawnSync(cli, [...args, "--install-extension", "smithy-vscode.vsix"], {
+    const result = spawnSync(cli, [...args, "--install-extension", "smithy-vscode.vsix", "--force"], {
       encoding: "utf-8",
     });
     assert.equal(result.status, 0);


### PR DESCRIPTION
This PR updates the extension to use version `0.1.0` of the Smithy Language Server which is not publish to Maven Central.

The extension can be configured to use other versions of the Smithy Language Server, including those published locally to Maven Local, by setting a different version string in the extension's settings:

![extension_configuration](https://user-images.githubusercontent.com/782571/172717669-bb295b9d-6dcc-493a-b064-d529bfc44bc7.png)

The integration tests are updated to force installation of the version being tested. This prevents failures if VS Code already has a newer version of the extension already installed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
