### PR TITLE
Change extension ID used for publishing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smithy-vscode",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "smithy-vscode",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "follow-redirects": "^1.14.9",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "smithy-vscode",
+  "name": "smithy-vscode-extension",
   "displayName": "Smithy",
   "description": "Smithy IDL Language Extension",
   "version": "0.4.0",


### PR DESCRIPTION
Updates the extension ID used for publishing since `smithy-vscode` was already in use.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
