### PR TITLE
Update VSCE and install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,16 @@ Additionally, it provides [Snippets](https://code.visualstudio.com/docs/editor/u
 
 ## Installation
 
-### VS Code
+This extension can be installed from the
+[VS Code Extension Marketplace](https://marketplace.visualstudio.com/items?itemName=smithy.smithy-vscode-extension).
 
-This extension is not yet published. To use this extension, manually installing
-the Extension with the following steps:
-* Clone the Extension: `git clone https://github.com/awslabs/smithy-vscode.git && cd smithy-vscode`
+To install from source, follow these steps:
+* Clone the repository: `git clone https://github.com/awslabs/smithy-vscode.git && cd smithy-vscode`
 * Run npm commands to install:
 `npm install && npm run install-plugin`
-* Open VS Code and add a `smithy-build.json` file to the root of your project,
-specifying any Maven dependencies used by your model, along with the
+
+## Authoring a model
+If your model requires dependencies, add a `smithy-build.json` file to the root of your project, specifying Maven dependencies, along with the
 repositories where they can be located.
 ```
 {
@@ -32,12 +33,12 @@ repositories where they can be located.
   }
 }
 ```
-* Start authoring your Smithy model. Opening a `*.smithy` file will activate
+Start authoring your Smithy model. Opening a `*.smithy` file will activate
 the extension.
 
-### IntelliJ
+## Use with IntelliJ
 
-You can use this extension in IntelliJ by installing the
+You can use this extension for syntax highlighting in IntelliJ by installing the
 "TextMate bundle support" plugin and registering this repository as a bundle.
 See the [IntelliJ documentation](https://www.jetbrains.com/help/idea/textmate.html)
 for more details.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "smithy-vscode",
+  "name": "smithy-vscode-extension",
   "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "smithy-vscode",
+      "name": "smithy-vscode-extension",
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -28,7 +28,7 @@
         "sinon": "^13.0.2",
         "ts-loader": "^9.3.0",
         "typescript": "^4.6.3",
-        "vsce": "^2.8.0",
+        "vsce": "^2.9.1",
         "vscode-nls-dev": "^4.0.0",
         "webpack": "^5.72.1",
         "webpack-cli": "^4.9.2"
@@ -3981,9 +3981,9 @@
       }
     },
     "node_modules/vsce": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.8.0.tgz",
-      "integrity": "sha512-p6BTbUVp33Ed0OWRRhRQT55yrmgLEca2fTmqxZJW44T1eP4yVWEsdaNIDsjFIeuCrjG/CYvwi1QLG4ql0s7bDA==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.9.1.tgz",
+      "integrity": "sha512-l/X4hkoYgOoZhRYQpJXqexBJU2z4mzNywx+artzWnOV3v45YMM6IoDDtIcB9SWluobem476KmMPLkCdAdnvoOg==",
       "dev": true,
       "dependencies": {
         "azure-devops-node-api": "^11.0.1",
@@ -7586,9 +7586,9 @@
       }
     },
     "vsce": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.8.0.tgz",
-      "integrity": "sha512-p6BTbUVp33Ed0OWRRhRQT55yrmgLEca2fTmqxZJW44T1eP4yVWEsdaNIDsjFIeuCrjG/CYvwi1QLG4ql0s7bDA==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.9.1.tgz",
+      "integrity": "sha512-l/X4hkoYgOoZhRYQpJXqexBJU2z4mzNywx+artzWnOV3v45YMM6IoDDtIcB9SWluobem476KmMPLkCdAdnvoOg==",
       "dev": true,
       "requires": {
         "azure-devops-node-api": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "sinon": "^13.0.2",
     "ts-loader": "^9.3.0",
     "typescript": "^4.6.3",
-    "vsce": "^2.8.0",
+    "vsce": "^2.9.1",
     "vscode-nls-dev": "^4.0.0",
     "webpack": "^5.72.1",
     "webpack-cli": "^4.9.2"


### PR DESCRIPTION
This PR upgrades VSCE and updates the README now that the extension can be installed from the [VS Code Extension Marketplace](https://marketplace.visualstudio.com/items?itemName=smithy.smithy-vscode-extension).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
