### PR TITLE
Enable extension tests for CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "format-check": "prettier --check '**/*.{ts,js,json,yml}'",
     "test-grammar": "npx vscode-tmgrammar-test -s 'source.smithy' -g syntaxes/smithy.tmLanguage.json -t 'tests/grammar/*'",
     "test-extension": "npm run compile && npm run package && node ./out/tests/runTest.js",
-    "test": "npm run format-check && npm run test-grammar"
+    "test": "npm run format-check && npm run test-grammar && npm run test-extension"
   },
   "devDependencies": {
     "@types/follow-redirects": "^1.14.1",

--- a/tests/helper.ts
+++ b/tests/helper.ts
@@ -16,7 +16,7 @@ export const getDocUri = (p: string) => {
 
 export async function waitForServerStartup() {
   // Wait for Smithy Language Server to start
-  await new Promise((resolve) => setTimeout(resolve, 6000));
+  await new Promise((resolve) => setTimeout(resolve, 9000));
 }
 
 export async function getLangServerLogs(p: string): Promise<string> {

--- a/tests/suite1/extension.test.ts
+++ b/tests/suite1/extension.test.ts
@@ -7,8 +7,14 @@ suite("Extension tests", () => {
     const smithyMainUri = getDocUri("suite1/main.smithy");
     const doc = await vscode.workspace.openTextDocument(smithyMainUri);
     const editor = await vscode.window.showTextDocument(doc);
-    const ext = vscode.extensions.getExtension("aws-smithy.smithy-vscode");
+    const ext = vscode.extensions.getExtension("smithy.smithy-vscode-extension");
     await waitForServerStartup();
+
+    // Grab model file directly
+    const modelFile = await vscode.workspace.openTextDocument(getDocUri("suite1/main.smithy"));
+    const modelFileText = modelFile.getText();
+
+    assert.match(modelFileText, /namespace example.weather/);
 
     // Grab Language Server logs
     const logText = await getLangServerLogs("suite1");
@@ -18,7 +24,7 @@ suite("Extension tests", () => {
     assert.equal(ext.isActive, true);
     assert.match(logText, /Downloaded external jars.*smithy-aws-traits-1\.19\.0\.jar/);
     assert.match(logText, /Discovered smithy files.*\/main.smithy]/);
-  }).timeout(7000);
+  }).timeout(10000);
 
   test("Should register language", async () => {
     const languages = await vscode.languages.getLanguages();

--- a/tests/suite2/extension.test.ts
+++ b/tests/suite2/extension.test.ts
@@ -13,5 +13,5 @@ suite("broken model tests", () => {
     assert.match(diagnostics[0].message, /relationship to an unresolved shape `example.weather#GetCurrentTime`/);
     assert.equal(diagnostics[0].range.start.line, 5);
     assert.equal(diagnostics[0].range.start.character, 0);
-  }).timeout(7000);
+  }).timeout(10000);
 });


### PR DESCRIPTION
This PR enables the extension tests to be run with CI. It also fixes the test to use the new extension ID: `smithy.smithy-vscode-extension`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
