### PR TITLE
Support enumValue and default value syntactic sugar

### DIFF
--- a/syntaxes/smithy.tmLanguage.json
+++ b/syntaxes/smithy.tmLanguage.json
@@ -434,6 +434,10 @@
           "name": "punctuation.separator.dictionary.key-value.smithy"
         },
         {
+          "match": "=",
+          "name": "keyword.operator.smithy"
+        },
+        {
           "name": "meta.structure.dictionary.value.smithy",
           "include": "#value"
         },

--- a/tests/grammar/aggregate-shapes.smithy
+++ b/tests/grammar/aggregate-shapes.smithy
@@ -60,6 +60,21 @@ structure Structure {
 }
 // <- punctuation.definition.dictionary.end.smithy
 
+structure StructureWithDefaultTraitSugar {
+// <---------                              keyword.statement.smithy
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   entity.name.type.smithy
+//                                       ^ punctuation.definition.dictionary.begin.smithy
+
+    normative: Boolean = true
+//  ^^^^^^^^^                 support.type.property-name.smithy
+//           ^                punctuation.separator.dictionary.key-value.smithy
+//             ^^^^^^^        entity.name.type.smithy
+//                     ^      keyword.operator.smithy
+//                       ^^^^ constant.language.smithy
+
+}
+// <- punctuation.definition.dictionary.end.smithy
+
 union Union {
 // <-----     keyword.statement.smithy
 //    ^^^^^   entity.name.type.smithy

--- a/tests/grammar/enums.smithy
+++ b/tests/grammar/enums.smithy
@@ -1,4 +1,4 @@
-// SYNTAX TEST "source.smithy" "This tests aggregate shapes"
+// SYNTAX TEST "source.smithy" "This tests enum and intEnum shapes"
 $version: "2.0"
 
 namespace com.example
@@ -21,6 +21,19 @@ enum Enum {
 }
 // <- punctuation.definition.dictionary.end.smithy
 
+enum EnumWithEnumValueTraitSugar {
+// <----                           keyword.statement.smithy
+//   ^^^^^^^^^^^^^^^^^^^^^^^^^^^   entity.name.type.smithy
+//                               ^ punctuation.definition.dictionary.begin.smithy
+
+    MEMBER = "member"
+//  ^^^^^^ entity.name.type.smithy
+//         ^ keyword.operator.smithy
+//           ^^^^^^^^ string.quoted.double.smithy
+
+}
+// <- punctuation.definition.dictionary.end.smithy
+
 intEnum IntEnum {
 // <-------       keyword.statement.smithy
 //      ^^^^^^^   entity.name.type.smithy
@@ -35,6 +48,19 @@ intEnum IntEnum {
 
     MEMBER
 //  ^^^^^^ entity.name.type.smithy
+
+}
+// <- punctuation.definition.dictionary.end.smithy
+
+intEnum IntEnumWithEnumValueTraitSugar {
+// <-------                              keyword.statement.smithy
+//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   entity.name.type.smithy
+//                                     ^ punctuation.definition.dictionary.begin.smithy
+
+    MEMBER = 1
+//  ^^^^^^     entity.name.type.smithy
+//         ^   keyword.operator.smithy
+//           ^ constant.numeric.smithy
 
 }
 // <- punctuation.definition.dictionary.end.smithy

--- a/tests/grammar/service-shapes.smithy
+++ b/tests/grammar/service-shapes.smithy
@@ -1,4 +1,4 @@
-// SYNTAX TEST "source.smithy" "This tests resource shapes"
+// SYNTAX TEST "source.smithy" "This tests service shapes"
 $version: "2.0"
 
 namespace com.example

--- a/tests/grammar/target-elision.smithy
+++ b/tests/grammar/target-elision.smithy
@@ -1,4 +1,4 @@
-// SYNTAX TEST "source.smithy" "This tests aggregate shapes"
+// SYNTAX TEST "source.smithy" "This tests target elision"
 $version: "2.0"
 
 namespace smithy.example


### PR DESCRIPTION
This PR updates the TextMate grammar to support the syntactic sugar that can be used to apply enumValue traits in enum and intEnum shapes and custom default values in structure shapes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
