### PR TITLE
Use Language Server 0.2.0 for Smithy IDL 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
         "smithyLsp.version": {
           "scope": "window",
           "type": "string",
-          "default": "0.1.0",
+          "default": "0.2.0",
           "description": "Version of the Smithy LSP (see https://github.com/smithy/smithy-language-server)"
         }
       }

--- a/test-fixtures/suite1/main.smithy
+++ b/test-fixtures/suite1/main.smithy
@@ -4,13 +4,13 @@ namespace example.weather
 
 /// Provides weather forecasts.
 service Weather {
-    version: "2006-03-01",
+    version: "2006-03-01"
     operations: [GetCurrentTime]
 }
 
 @readonly
 operation GetCurrentTime {
-    input := {},
+    input := {}
     output := {
         @required
         time: Timestamp

--- a/test-fixtures/suite1/main.smithy
+++ b/test-fixtures/suite1/main.smithy
@@ -1,4 +1,4 @@
-$version: "1.0"
+$version: "2.0"
 
 namespace example.weather
 
@@ -10,15 +10,9 @@ service Weather {
 
 @readonly
 operation GetCurrentTime {
-    input: GetCurrentTimeInput,
-    output: GetCurrentTimeOutput
-}
-
-@input
-structure GetCurrentTimeInput {}
-
-@output
-structure GetCurrentTimeOutput {
-    @required
-    time: Timestamp
+    input := {},
+    output := {
+        @required
+        time: Timestamp
+    }
 }

--- a/test-fixtures/suite1/smithy-build.json
+++ b/test-fixtures/suite1/smithy-build.json
@@ -1,6 +1,6 @@
 {
   "maven": {
-    "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.19.0"],
+    "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.23.1"],
     "repositories": [{ "url": "https://repo1.maven.org/maven2/" }]
   }
 }

--- a/test-fixtures/suite2/main.smithy
+++ b/test-fixtures/suite2/main.smithy
@@ -4,6 +4,6 @@ namespace example.weather
 
 /// Provides weather forecasts.
 service Weather {
-    version: "2006-03-01",
+    version: "2006-03-01"
     operations: [GetCurrentTime]
 }

--- a/test-fixtures/suite2/main.smithy
+++ b/test-fixtures/suite2/main.smithy
@@ -1,4 +1,4 @@
-$version: "1.0"
+$version: "2.0"
 
 namespace example.weather
 

--- a/test-fixtures/suite2/smithy-build.json
+++ b/test-fixtures/suite2/smithy-build.json
@@ -1,6 +1,6 @@
 {
   "maven": {
-    "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.19.0"],
+    "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.23.1"],
     "repositories": [{ "url": "https://repo1.maven.org/maven2/" }]
   }
 }

--- a/test-fixtures/suite3/main.smithy
+++ b/test-fixtures/suite3/main.smithy
@@ -6,21 +6,21 @@ namespace example.weather
 @paginated(inputToken: "nextToken", outputToken: "nextToken",
            pageSize: "pageSize")
 service Weather {
-    version: "2006-03-01",
-    resources: [City],
+    version: "2006-03-01"
+    resources: [City]
     operations: [GetCurrentTime]
 }
 
 resource City {
-    identifiers: { cityId: CityId },
-    read: GetCity,
-    list: ListCities,
-    resources: [Forecast],
+    identifiers: { cityId: CityId }
+    read: GetCity
+    list: ListCities
+    resources: [Forecast]
 }
 
 resource Forecast {
-    identifiers: { cityId: CityId },
-    read: GetForecast,
+    identifiers: { cityId: CityId }
+    read: GetForecast
 }
 
 // "pattern" is a trait.
@@ -29,8 +29,8 @@ string CityId
 
 @readonly
 operation GetCity {
-    input: GetCityInput,
-    output: GetCityOutput,
+    input: GetCityInput
+    output: GetCityOutput
     errors: [NoSuchResource]
 }
 
@@ -47,19 +47,19 @@ structure GetCityOutput {
     // "required" is used on output to indicate if the service
     // will always provide a value for the member.
     @required
-    name: String,
+    name: String
 
     @required
-    coordinates: CityCoordinates,
+    coordinates: CityCoordinates
 }
 
 // This structure is nested within GetCityOutput.
 structure CityCoordinates {
     @required
-    latitude: Float,
+    latitude: Float
 
     @required
-    longitude: Float,
+    longitude: Float
 }
 
 // "error" is a trait that is used to specialize
@@ -75,22 +75,22 @@ structure NoSuchResource {
 @readonly
 @paginated(items: "items")
 operation ListCities {
-    input: ListCitiesInput,
+    input: ListCitiesInput
     output: ListCitiesOutput
 }
 
 @input
 structure ListCitiesInput {
-    nextToken: String,
+    nextToken: String
     pageSize: Integer
 }
 
 @output
 structure ListCitiesOutput {
-    nextToken: String,
+    nextToken: String
 
     @required
-    items: CitySummaries,
+    items: CitySummaries
 }
 
 // CitySummaries is a list of CitySummary structures.
@@ -102,15 +102,15 @@ list CitySummaries {
 @references([{resource: City}])
 structure CitySummary {
     @required
-    cityId: CityId,
+    cityId: CityId
 
     @required
-    name: String,
+    name: String
 }
 
 @readonly
 operation GetCurrentTime {
-    input: GetCurrentTimeInput,
+    input: GetCurrentTimeInput
     output: GetCurrentTimeOutput
 }
 
@@ -125,7 +125,7 @@ structure GetCurrentTimeOutput {
 
 @readonly
 operation GetForecast {
-    input: GetForecastInput,
+    input: GetForecastInput
     output: GetForecastOutput
 }
 
@@ -134,7 +134,7 @@ operation GetForecast {
 @input
 structure GetForecastInput {
     @required
-    cityId: CityId,
+    cityId: CityId
 }
 
 @output

--- a/test-fixtures/suite3/main.smithy
+++ b/test-fixtures/suite3/main.smithy
@@ -1,4 +1,4 @@
-$version: "1.0"
+$version: "2.0"
 
 namespace example.weather
 

--- a/test-fixtures/suite3/smithy-build.json
+++ b/test-fixtures/suite3/smithy-build.json
@@ -1,6 +1,6 @@
 {
   "maven": {
-    "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.19.0"],
+    "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.23.1"],
     "repositories": [{ "url": "https://repo1.maven.org/maven2/" }]
   }
 }

--- a/tests/suite1/extension.test.ts
+++ b/tests/suite1/extension.test.ts
@@ -9,6 +9,7 @@ suite("Extension tests", () => {
     const editor = await vscode.window.showTextDocument(doc);
     const ext = vscode.extensions.getExtension("smithy.smithy-vscode-extension");
     await waitForServerStartup();
+    const diagnostics = vscode.languages.getDiagnostics(smithyMainUri);
 
     // Grab model file directly
     const modelFile = await vscode.workspace.openTextDocument(getDocUri("suite1/main.smithy"));
@@ -22,8 +23,9 @@ suite("Extension tests", () => {
     assert.notEqual(doc, undefined);
     assert.notEqual(editor, undefined);
     assert.equal(ext.isActive, true);
-    assert.match(logText, /Downloaded external jars.*smithy-aws-traits-1\.19\.0\.jar/);
+    assert.match(logText, /Downloaded external jars.*smithy-aws-traits-1\.23\.1\.jar/);
     assert.match(logText, /Discovered smithy files.*\/main.smithy]/);
+    assert.equal(diagnostics.length, 0);
   }).timeout(10000);
 
   test("Should register language", async () => {

--- a/tests/suite2/extension.test.ts
+++ b/tests/suite2/extension.test.ts
@@ -6,7 +6,7 @@ suite("broken model tests", () => {
   test("Should provide diagnostics", async () => {
     const smithyMainUri = getDocUri("suite2/main.smithy");
     const doc = await vscode.workspace.openTextDocument(smithyMainUri);
-    const editor = await vscode.window.showTextDocument(doc);
+    await vscode.window.showTextDocument(doc);
     await waitForServerStartup();
     const diagnostics = vscode.languages.getDiagnostics(smithyMainUri);
 


### PR DESCRIPTION
Upgrades the extension to use version `0.2.0` of the Smithy Language Server, which has support for Smithy IDL 2.

CI will fail since `0.2.0` of the Smithy Language Server has not yet been published.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
