### PR TITLE
feat: add root path configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ repositories where they can be located.
 {
     {
     "maven": {
-      "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.23.1"],
+      "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.25.0"],
       "repositories": [{ "url": "https://repo1.maven.org/maven2/" }]
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "follow-redirects": "^1.14.9",
-        "vscode-languageclient": "^7.0.0",
+        "vscode-languageclient": "^8.0.2",
         "vscode-nls": "^5.2.0",
         "vscode-tmgrammar-test": "^0.1.1"
       },
@@ -4046,24 +4046,24 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
+      "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
       "engines": {
-        "node": ">=8.0.0 || >=10.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
-      "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
+      "integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
       "dependencies": {
         "minimatch": "^3.0.4",
-        "semver": "^7.3.4",
-        "vscode-languageserver-protocol": "3.16.0"
+        "semver": "^7.3.5",
+        "vscode-languageserver-protocol": "3.17.2"
       },
       "engines": {
-        "vscode": "^1.52.0"
+        "vscode": "^1.67.0"
       }
     },
     "node_modules/vscode-languageclient/node_modules/lru-cache": {
@@ -4089,18 +4089,18 @@
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
+      "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
       "dependencies": {
-        "vscode-jsonrpc": "6.0.0",
-        "vscode-languageserver-types": "3.16.0"
+        "vscode-jsonrpc": "8.0.2",
+        "vscode-languageserver-types": "3.17.2"
       }
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+      "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
     },
     "node_modules/vscode-nls": {
       "version": "5.2.0",
@@ -7656,18 +7656,18 @@
       }
     },
     "vscode-jsonrpc": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
+      "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ=="
     },
     "vscode-languageclient": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
-      "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
+      "integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
       "requires": {
         "minimatch": "^3.0.4",
-        "semver": "^7.3.4",
-        "vscode-languageserver-protocol": "3.16.0"
+        "semver": "^7.3.5",
+        "vscode-languageserver-protocol": "3.17.2"
       },
       "dependencies": {
         "lru-cache": {
@@ -7686,18 +7686,18 @@
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
+      "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
       "requires": {
-        "vscode-jsonrpc": "6.0.0",
-        "vscode-languageserver-types": "3.16.0"
+        "vscode-jsonrpc": "8.0.2",
+        "vscode-languageserver-types": "3.17.2"
       }
     },
     "vscode-languageserver-types": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+      "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
     },
     "vscode-nls": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,10 @@
           "type": "string",
           "default": "0.2.0",
           "description": "Version of the Smithy LSP (see https://github.com/smithy/smithy-language-server)"
+        },
+        "smithyLsp.rootPath": {
+          "scope": "resource",
+          "type": "string"
         }
       }
     }
@@ -142,7 +146,7 @@
   },
   "dependencies": {
     "follow-redirects": "^1.14.9",
-    "vscode-languageclient": "^7.0.0",
+    "vscode-languageclient": "^8.0.2",
     "vscode-nls": "^5.2.0",
     "vscode-tmgrammar-test": "^0.1.1"
   }

--- a/test-fixtures/suite1/main.smithy
+++ b/test-fixtures/suite1/main.smithy
@@ -2,13 +2,20 @@ $version: "2.0"
 
 namespace example.weather
 
+use aws.api#dataPlane
+use aws.api#service
+
 /// Provides weather forecasts.
+@service(
+  sdkId: "Weather",
+)
 service Weather {
     version: "2006-03-01"
     operations: [GetCurrentTime]
 }
 
 @readonly
+@dataPlane
 operation GetCurrentTime {
     input := {}
     output := {

--- a/test-fixtures/suite4/.vscode/settings.json
+++ b/test-fixtures/suite4/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "smithyLsp.rootPath": "${workspaceRoot}/smithy"
+}

--- a/test-fixtures/suite4/smithy/main.smithy
+++ b/test-fixtures/suite4/smithy/main.smithy
@@ -1,0 +1,59 @@
+$version: "2.0"
+
+namespace example.weather
+
+use aws.api#dataPlane
+use smithy.waiters#waitable
+
+/// Provides weather forecasts.
+service Weather {
+    version: "2006-03-01"
+    operations: [GetCurrentTime, GetWeatherReport]
+}
+
+@readonly
+@dataPlane
+operation GetCurrentTime {
+    input := {}
+    output := {
+        @required
+        time: Timestamp
+    }
+}
+
+@waitable(
+    ReportGenerated: {
+        documentation: "Wait until the weather report is generated"
+        acceptors: [
+            {
+                state: "success"
+                matcher: {
+                    success: true
+                }
+            }
+            {
+                state: "retry"
+                matcher: {
+                    errorType: "NotFound"
+                }
+            }
+        ]
+    }
+)
+operation GetWeatherReport {
+    input := {
+        @required
+        cityId: String
+    }
+    output := {
+        @required
+        temperature: String
+    }
+    errors: [NotFound]
+}
+
+@error("client")
+structure NotFound {
+    @required
+    message: String
+}

--- a/test-fixtures/suite4/smithy/smithy-build.json
+++ b/test-fixtures/suite4/smithy/smithy-build.json
@@ -1,0 +1,6 @@
+{
+  "maven": {
+    "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.25.0", "software.amazon.smithy:smithy-waiters:1.25.0"],
+    "repositories": [{ "url": "https://repo1.maven.org/maven2/" }]
+  }
+}

--- a/tests/runTest.ts
+++ b/tests/runTest.ts
@@ -34,6 +34,13 @@ async function go() {
       launchArgs: [resolve(__dirname, "../../test-fixtures/suite3")],
     });
 
+    // Suite 4 - User-specific root
+    await runTests({
+      extensionDevelopmentPath,
+      extensionTestsPath: resolve(__dirname, "./suite4"),
+      launchArgs: [resolve(__dirname, "../../test-fixtures/suite4")],
+    });
+
     // Confirm that webpacked and vsce packaged extension can be installed.
     const vscodeExecutablePath = await downloadAndUnzipVSCode();
     const [cli, ...args] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);

--- a/tests/suite4/extension.test.ts
+++ b/tests/suite4/extension.test.ts
@@ -1,0 +1,19 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { getDocUri, getLangServerLogs, waitForServerStartup } from "../helper";
+
+suite("User-specific root", () => {
+  test("Should download jars even when not in workspace root", async () => {
+    const smithyMainUri = getDocUri("suite4/smithy/main.smithy");
+    const doc = await vscode.workspace.openTextDocument(smithyMainUri);
+    await vscode.window.showTextDocument(doc);
+    await waitForServerStartup();
+    const diagnostics = vscode.languages.getDiagnostics(smithyMainUri);
+    const logText = await getLangServerLogs("suite4/smithy");
+
+    assert.match(logText, /Downloaded external jars.*smithy-aws-traits-1\.25\.0\.jar/);
+    assert.match(logText, /Downloaded external jars.*smithy-waiters-1\.25\.0\.jar/);
+    assert.doesNotMatch(logText, /Unable to resolve trait/);
+    assert.equal(diagnostics.length, 0);
+  }).timeout(10000);
+});

--- a/tests/suite4/index.ts
+++ b/tests/suite4/index.ts
@@ -1,0 +1,5 @@
+import { runTests } from "../helper";
+
+export function run(testsRoot: string, cb: (error: any, failures?: number) => void): void {
+  runTests(testsRoot, cb);
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Allow users to customize the root path to be used by the Smithy VSCode extension. Otherwise, whenever we have the `smithy-build.json` file not in the workspace root, it fails with the following (as per commit [6e8f997](https://github.com/awslabs/smithy-vscode/pull/54/commits/6e8f9973f3645d15d954d4acdc0bf7e97678da8e)):

<details>
  <summary>Dump from .smithy.lsp.log</summary>

[18:14:14] Created a temporary folder for file contents /var/folders/dc/07t_8b2n41lgnz09y651104w0000gn/T/smithy-lsp7987430497366641088
[18:14:14] Recreating project from /smithy-vscode/test-fixtures/suite1
[18:14:14] Imports from config: [/smithy-vscode/test-fixtures/suite1] will be resolved against root /smithy-vscode/test-fixtures/suite1
[18:14:14] Discovered smithy files: [/smithy-vscode/test-fixtures/suite1/smithy/main.smithy]
[18:14:14] Downloading external dependencies for SmithyBuildExtensions(repositories = [], artifacts = [], imports = [])
[18:14:14] Downloaded external jars: []
[18:14:14] [ERROR] example.weather#GetCurrentTime: Unable to resolve trait `aws.api#dataPlane`. If this is a custom trait, then it must be defined before it can be used in a model. | Model /smithy-vscode/test-fixtures/suite1/smithy/main.smithy:18:1
[18:14:14] [ERROR] example.weather#Weather: Unable to resolve trait `aws.api#service`. If this is a custom trait, then it must be defined before it can be used in a model. | Model /smithy-vscode/test-fixtures/suite1/smithy/main.smithy:9:1
[18:14:14] Recreating project from /smithy-vscode/test-fixtures/suite1
[18:14:14] Imports from config: [/smithy-vscode/test-fixtures/suite1] will be resolved against root /smithy-vscode/test-fixtures/suite1
[18:14:14] Discovered smithy files: [/smithy-vscode/test-fixtures/suite1/smithy/main.smithy]
[18:14:14] Downloading external dependencies for SmithyBuildExtensions(repositories = [], artifacts = [], imports = [])
[18:14:14] Downloaded external jars: []
[18:14:14] [ERROR] example.weather#GetCurrentTime: Unable to resolve trait `aws.api#dataPlane`. If this is a custom trait, then it must be defined before it can be used in a model. | Model /smithy-vscode/test-fixtures/suite1/smithy/main.smithy:18:1
[18:14:14] [ERROR] example.weather#Weather: Unable to resolve trait `aws.api#service`. If this is a custom trait, then it must be defined before it can be used in a model. | Model /smithy-vscode/test-fixtures/suite1/smithy/main.smithy:9:1
[18:14:14] [ERROR] example.weather#GetCurrentTime: Unable to resolve trait `aws.api#dataPlane`. If this is a custom trait, then it must be defined before it can be used in a model. | Model /smithy-vscode/test-fixtures/suite1/smithy/main.smithy:18:1
[18:14:14] [ERROR] example.weather#Weather: Unable to resolve trait `aws.api#service`. If this is a custom trait, then it must be defined before it can be used in a model. | Model /smithy-vscode/test-fixtures/suite1/smithy/main.smithy:9:1
[18:14:14] Recompiling /smithy-vscode/test-fixtures/suite1/smithy/main.smithy (with temporary content Optional.empty) raised 2  diagnostics

</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
