### PR TITLE
feat: never reveal output window when returning

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import {
   LanguageClient,
   LanguageClientOptions,
   RequestType,
+  RevealOutputChannelOn,
   StreamInfo,
   TextDocumentIdentifier,
 } from "vscode-languageclient/node";
@@ -119,6 +120,9 @@ export function activate(context: ExtensionContext) {
       fileEvents: workspace.createFileSystemWatcher("**/{smithy-build}.json"),
     },
     outputChannelName: "Smithy Language Server",
+
+    // Don't switch to output window when the server returns output.
+    revealOutputChannelOn: RevealOutputChannelOn.Never,
   };
 
   // Create the language client and start the client.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

By default, whenever the extension sends a message, the focus is switched to VSCode's output window. This change will prevent that from happening so that the user can choose when to check those messages.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
