### PR TITLE
Register formatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
         "smithyLsp.version": {
           "scope": "window",
           "type": "string",
-          "default": "0.2.2",
+          "default": "0.2.3",
           "description": "Version of the Smithy LSP (see https://github.com/smithy/smithy-language-server)"
         },
         "smithyLsp.rootPath": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { selectorRunCommandHandler, selectorClearCommandHandler } from "./select
 
 import {
   CancellationToken,
+  DocumentFormattingRequest,
   LanguageClient,
   LanguageClientOptions,
   RequestType,
@@ -116,6 +117,9 @@ export function activate(context: vscode.ExtensionContext) {
   const smithyContentProvider = createSmithyContentProvider(client);
   context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider("smithyjar", smithyContentProvider));
 
+  const smithyFormattingEditProvider = createSmithyFormattingEditProvider(client);
+  context.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider("smithy", smithyFormattingEditProvider));
+
   // Set default expression input, and use context to hold state between command invocations.
   this.expression = "Enter Selector Expression";
   this.selectorDecorator = new SelectorDecorator();
@@ -203,6 +207,19 @@ function createSmithyContentProvider(languageClient: LanguageClient): vscode.Tex
           return v || "";
         });
     },
+  };
+}
+
+function createSmithyFormattingEditProvider(languageClient: LanguageClient): vscode.DocumentFormattingEditProvider {
+  return <vscode.DocumentFormattingEditProvider>{
+    provideDocumentFormattingEdits: async (document: vscode.TextDocument, options: vscode.FormattingOptions, token: CancellationToken): Promise<vscode.TextEdit[]> => {
+      document.uri
+      return languageClient
+        .sendRequest(DocumentFormattingRequest.type, { textDocument: { uri: document.uri.toString() }, options: options }, token)
+        .then((v: vscode.TextEdit[]): vscode.TextEdit[] => {
+          return v;
+        });
+    }
   };
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -118,7 +118,9 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider("smithyjar", smithyContentProvider));
 
   const smithyFormattingEditProvider = createSmithyFormattingEditProvider(client);
-  context.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider("smithy", smithyFormattingEditProvider));
+  context.subscriptions.push(
+    vscode.languages.registerDocumentFormattingEditProvider("smithy", smithyFormattingEditProvider)
+  );
 
   // Set default expression input, and use context to hold state between command invocations.
   this.expression = "Enter Selector Expression";
@@ -212,14 +214,22 @@ function createSmithyContentProvider(languageClient: LanguageClient): vscode.Tex
 
 function createSmithyFormattingEditProvider(languageClient: LanguageClient): vscode.DocumentFormattingEditProvider {
   return <vscode.DocumentFormattingEditProvider>{
-    provideDocumentFormattingEdits: async (document: vscode.TextDocument, options: vscode.FormattingOptions, token: CancellationToken): Promise<vscode.TextEdit[]> => {
-      document.uri
+    provideDocumentFormattingEdits: async (
+      document: vscode.TextDocument,
+      options: vscode.FormattingOptions,
+      token: CancellationToken
+    ): Promise<vscode.TextEdit[]> => {
+      document.uri;
       return languageClient
-        .sendRequest(DocumentFormattingRequest.type, { textDocument: { uri: document.uri.toString() }, options: options }, token)
+        .sendRequest(
+          DocumentFormattingRequest.type,
+          { textDocument: { uri: document.uri.toString() }, options: options },
+          token
+        )
         .then((v: vscode.TextEdit[]): vscode.TextEdit[] => {
           return v;
         });
-    }
+    },
   };
 }
 

--- a/test-fixtures/suite5/.vscode/settings.json
+++ b/test-fixtures/suite5/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "smithyLsp.rootPath": "${workspaceRoot}/smithy",
+}

--- a/test-fixtures/suite5/smithy/main.smithy
+++ b/test-fixtures/suite5/smithy/main.smithy
@@ -1,0 +1,14 @@
+$version: "2.0"
+
+namespace example.weather
+
+/// Provides weather forecasts.
+service Weather {
+    version: "2006-03-01"
+    operations: [GetCurrentTime]
+}
+
+operation GetCurrentTime {
+    // Below line to be indented.
+input := {}
+}

--- a/test-fixtures/suite5/smithy/smithy-build.json
+++ b/test-fixtures/suite5/smithy/smithy-build.json
@@ -1,0 +1,6 @@
+{
+  "maven": {
+    "dependencies": ["software.amazon.smithy:smithy-aws-traits:1.25.0", "software.amazon.smithy:smithy-waiters:1.25.0"],
+    "repositories": [{ "url": "https://repo1.maven.org/maven2/" }]
+  }
+}

--- a/tests/runTest.ts
+++ b/tests/runTest.ts
@@ -41,6 +41,13 @@ async function go() {
       launchArgs: [resolve(__dirname, "../../test-fixtures/suite4")],
     });
 
+    // Suite 5 - Formatter
+    await runTests({
+      extensionDevelopmentPath,
+      extensionTestsPath: resolve(__dirname, "./suite5"),
+      launchArgs: [resolve(__dirname, "../../test-fixtures/suite5")],
+    });
+
     // Confirm that webpacked and vsce packaged extension can be installed.
     const vscodeExecutablePath = await downloadAndUnzipVSCode();
     const [cli, ...args] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);

--- a/tests/suite5/extension.test.ts
+++ b/tests/suite5/extension.test.ts
@@ -1,0 +1,19 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { getDocUri, waitForServerStartup } from "../helper";
+
+suite("formatting tests", () => {
+  test("Should register Smithy formatter", async () => {
+    const smithyMainUri = getDocUri("suite5/smithy/main.smithy");
+    await waitForServerStartup();
+    const edits: vscode.TextEdit[] = await vscode.commands.executeCommand("vscode.executeFormatDocumentProvider", smithyMainUri);
+    const edit: vscode.TextEdit = edits[0];
+    const expectedRange = new vscode.Range(new vscode.Position(12, 0), new vscode.Position(12, 0))
+    const range = edit.range;
+    const newText = edit.newText;
+
+    assert.equal(edits.length, 1);
+    assert.equal(range.isEqual(expectedRange), true);
+    assert.equal(newText, "    ");
+  }).timeout(10000);
+});

--- a/tests/suite5/extension.test.ts
+++ b/tests/suite5/extension.test.ts
@@ -6,9 +6,12 @@ suite("formatting tests", () => {
   test("Should register Smithy formatter", async () => {
     const smithyMainUri = getDocUri("suite5/smithy/main.smithy");
     await waitForServerStartup();
-    const edits: vscode.TextEdit[] = await vscode.commands.executeCommand("vscode.executeFormatDocumentProvider", smithyMainUri);
+    const edits: vscode.TextEdit[] = await vscode.commands.executeCommand(
+      "vscode.executeFormatDocumentProvider",
+      smithyMainUri
+    );
     const edit: vscode.TextEdit = edits[0];
-    const expectedRange = new vscode.Range(new vscode.Position(12, 0), new vscode.Position(12, 0))
+    const expectedRange = new vscode.Range(new vscode.Position(12, 0), new vscode.Position(12, 0));
     const range = edit.range;
     const newText = edit.newText;
 

--- a/tests/suite5/extension.test.ts
+++ b/tests/suite5/extension.test.ts
@@ -5,6 +5,8 @@ import { getDocUri, waitForServerStartup } from "../helper";
 suite("formatting tests", () => {
   test("Should register Smithy formatter", async () => {
     const smithyMainUri = getDocUri("suite5/smithy/main.smithy");
+    const doc = await vscode.workspace.openTextDocument(smithyMainUri);
+    await vscode.window.showTextDocument(doc);
     await waitForServerStartup();
     const edits: vscode.TextEdit[] = await vscode.commands.executeCommand(
       "vscode.executeFormatDocumentProvider",

--- a/tests/suite5/index.ts
+++ b/tests/suite5/index.ts
@@ -1,0 +1,5 @@
+import { runTests } from "../helper";
+
+export function run(testsRoot: string, cb: (error: any, failures?: number) => void): void {
+  runTests(testsRoot, cb);
+}


### PR DESCRIPTION
Registers the Smithy formatter added in https://github.com/awslabs/smithy-language-server/pull/89.

WIP until version `0.2.3` of the Smithy Language Server has been published.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
