### PR TITLE
Upgrade GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Test Textmate syntax and extension
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14"
 


### PR DESCRIPTION
Updates CI to use actions/checkout@v3 and actions/setup-node@v3.

Follows example here: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions

checkout@v2 and setup-node@v2 use Node 12.x which is EOL.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
