### PR TITLE
Update grammar for apply stmt

### DIFF
--- a/syntaxes/smithy.tmLanguage.json
+++ b/syntaxes/smithy.tmLanguage.json
@@ -229,19 +229,19 @@
     },
     {
       "name": "meta.keyword.statement.apply.smithy",
-      "begin": "^(apply)\\s+([A-Z-a-z0-9_]+)\\s+",
+      "begin": "^(apply)\\s+",
       "end": "\\n",
       "beginCaptures": {
         "1": {
           "name": "keyword.statement.smithy"
-        },
-        "2": {
-          "name": "entity.name.type.smithy"
         }
       },
       "patterns": [
         {
           "include": "#trait"
+        },
+        {
+          "include": "#shapeid"
         },
         {
           "match": "[^\\n]",

--- a/tests/grammar/apply.smithy
+++ b/tests/grammar/apply.smithy
@@ -1,0 +1,18 @@
+// SYNTAX TEST "source.smithy" "This tests apply statements"
+$version: "2.0"
+
+namespace com.example
+
+string Foo
+
+apply Foo @mixin
+// <-----        keyword.statement.smithy
+//    ^^^        entity.name.type.smithy
+//        ^      punctuation.definition.annotation.smithy
+//         ^^^^^ storage.type.annotation.smithy
+
+apply com.example#Foo @mixin
+// <-----                       keyword.statement.smithy
+//    ^^^^^^^^^^^^^^^           entity.name.type.smithy
+//                    ^         punctuation.definition.annotation.smithy
+//                     ^^^^^    storage.type.annotation.smithy


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR makes highlighting work for apply statements with fully qualified shape ids.

Previously:
<img width="190" alt="old-apply" src="https://github.com/awslabs/smithy-vscode/assets/45497130/ce9f1ddf-7ba6-4df3-90f5-f612cb334269">

This PR:
<img width="179" alt="fixed-apply" src="https://github.com/awslabs/smithy-vscode/assets/45497130/a241d2f6-51ef-40be-abf3-a2636829a9b8">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
